### PR TITLE
feat: 도메인 모델 개선 및 문서 추가

### DIFF
--- a/GEMINI.MD
+++ b/GEMINI.MD
@@ -36,6 +36,38 @@
 - **`PromptDocument`:** OpenSearch에 저장될 비정규화된 검색용 문서.
 - **Events:** `PromptReceivedEvent` (수집 시점), `PromptAnalyzedEvent` (분석 완료 시점, Phase 2에서 사용).
 
+## 6. PR Creation Guidelines
+
+When creating a Pull Request, adhere to the following format to ensure clarity and provide sufficient context for reviewers. Use the `pr_body.md` file in the root directory as the base template.
+
+### PR Title
+- The title must follow the **Conventional Commits** specification.
+- Prefix the title with a type, such as `feat:`, `fix:`, `docs:`, `style:`, `refactor:`, `test:`, or `chore:`.
+- Example: `feat: 프롬프트 수집 API 및 서비스 초기 구현 (Task 007)`
+
+### PR Body
+The body should be detailed and structured according to the `pr_body.md` template.
+
+1.  **📝 Related Task**:
+    -   Clearly link the PR to the relevant task in the backlog.
+    -   Use the `Closes #task-XXX` syntax to automatically close the task upon merging.
+
+2.  **📄 Description**:
+    -   Provide a high-level summary of what the PR accomplishes and **why** the changes are being made.
+
+3.  **✨ Key Changes**:
+    -   Use a bulleted list to detail the main technical changes.
+    -   Mention new files, key architectural decisions, and significant refactoring.
+    -   Example: "테스트 환경 개선: `ControllerTestSupport`를 수정하여 모든 컨트롤러 테스트가 컨텍스트를 공유하도록 개선했습니다."
+
+4.  **🤖 To Reviewers**:
+    -   Guide the reviewers by highlighting specific areas that need close attention.
+    -   Ask for feedback on architectural decisions, correctness of logic, or adherence to conventions.
+
+5.  **✅ Checklist**:
+    -   Ensure the checklist from the template is included. The author of the PR is responsible for going through it before requesting a review.
+
+
 <!-- BACKLOG.MD GUIDELINES START -->
 # Instructions for the usage of Backlog.md CLI Tool
 

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/common/exception/EntityNotExistException.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/common/exception/EntityNotExistException.java
@@ -1,0 +1,19 @@
+package youngsu5582.tool.ai_tracker.common.exception;
+
+public class EntityNotExistException extends RuntimeException {
+
+    private final String entity;
+    private final long id;
+
+    public EntityNotExistException(Class<?> entity, long id) {
+        super("Entity Not Found. Entity: %s, Id: %d".formatted(entity.getName(), id));
+        this.entity = entity.getName();
+        this.id = id;
+    }
+
+    public EntityNotExistException(String entity, long id) {
+        super("Entity Not Found. Entity: %s, Id: %d".formatted(entity, id));
+        this.entity = entity;
+        this.id = id;
+    }
+}

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/category/Categories.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/category/Categories.java
@@ -1,0 +1,20 @@
+package youngsu5582.tool.ai_tracker.domain.category;
+
+import java.util.List;
+import java.util.Optional;
+
+public record Categories(
+    List<Category> categories
+) {
+
+    public Optional<Category> findCategory(String name) {
+        return categories.stream()
+            .filter(c -> c.getName().equals(name))
+            .findFirst();
+    }
+
+    public List<String> categoryNames() {
+        return categories.stream().map(Category::getName).toList();
+    }
+
+}

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/category/Categories.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/category/Categories.java
@@ -2,14 +2,18 @@ package youngsu5582.tool.ai_tracker.domain.category;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.util.StringUtils;
 
 public record Categories(
     List<Category> categories
 ) {
 
     public Optional<Category> findCategory(String name) {
+        if (!StringUtils.hasText(name)) {
+            return Optional.empty();
+        }
         return categories.stream()
-            .filter(c -> c.getName().equals(name))
+            .filter(c -> name.equals(c.getName()))
             .findFirst();
     }
 

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/category/Category.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/category/Category.java
@@ -17,7 +17,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -34,7 +33,6 @@ import youngsu5582.tool.ai_tracker.common.entity.AuditEntity;
 @EntityListeners(AuditingEntityListener.class)
 public class Category extends AuditEntity {
 
-    @ToString.Exclude
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/category/Category.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/category/Category.java
@@ -17,6 +17,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -33,6 +34,7 @@ import youngsu5582.tool.ai_tracker.common.entity.AuditEntity;
 @EntityListeners(AuditingEntityListener.class)
 public class Category extends AuditEntity {
 
+    @ToString.Exclude
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/category/CategoryRepository.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/category/CategoryRepository.java
@@ -8,4 +8,7 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     Optional<Category> findByUuid(UUID uuid);
 
+    default Categories findAllToFirstClass() {
+        return new Categories(findAll());
+    }
 }

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/prompt/Prompt.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/prompt/Prompt.java
@@ -6,9 +6,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
@@ -22,7 +24,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
@@ -56,12 +57,10 @@ public class Prompt extends AuditEntity {
     @Builder.Default
     private PromptStatus status = PromptStatus.RECEIVED;
 
-    @JdbcTypeCode(SqlTypes.VARCHAR)
-    @Column(length = 2048)
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
     private String payload;
 
-    @JdbcTypeCode(SqlTypes.VARCHAR)
-    @Column(length = 2048)
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
     private String error;
 
     @Column(nullable = false)
@@ -75,9 +74,13 @@ public class Prompt extends AuditEntity {
     @Builder.Default
     private Set<PromptTag> promptTags = new HashSet<>();
 
-    @Setter
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
     private Category category;
+
+    public void assignCategory(Category category) {
+        this.category = category;
+    }
 
     public void failAnalyze(String error) {
         this.status = PromptStatus.FAILED;

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/prompt/PromptProvider.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/prompt/PromptProvider.java
@@ -1,5 +1,16 @@
 package youngsu5582.tool.ai_tracker.domain.prompt;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+
+@Getter
 public enum PromptProvider {
-    OPEN_AI
+    OPEN_AI("open-ai");
+
+    @JsonValue
+    private final String alias;
+
+    PromptProvider(String alias) {
+        this.alias = alias;
+    }
 }

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/prompt/PromptProviderConverter.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/prompt/PromptProviderConverter.java
@@ -24,6 +24,6 @@ public class PromptProviderConverter implements AttributeConverter<PromptProvide
         return Stream.of(PromptProvider.values())
             .filter(c -> c.getAlias().equals(dbData))
             .findFirst()
-            .orElseThrow(IllegalArgumentException::new);
+            .orElseThrow(() -> new IllegalArgumentException("Unknown PromptProvider alias: " + dbData));
     }
 }

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/prompt/PromptProviderConverter.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/prompt/PromptProviderConverter.java
@@ -1,0 +1,29 @@
+package youngsu5582.tool.ai_tracker.domain.prompt;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.stream.Stream;
+
+@Converter(autoApply = true)
+public class PromptProviderConverter implements AttributeConverter<PromptProvider, String> {
+
+    @Override
+    public String convertToDatabaseColumn(PromptProvider attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        return attribute.getAlias();
+    }
+
+    @Override
+    public PromptProvider convertToEntityAttribute(String dbData) {
+        if (dbData == null) {
+            return null;
+        }
+
+        return Stream.of(PromptProvider.values())
+            .filter(c -> c.getAlias().equals(dbData))
+            .findFirst()
+            .orElseThrow(IllegalArgumentException::new);
+    }
+}

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/prompt/PromptRepository.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/prompt/PromptRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import youngsu5582.tool.ai_tracker.common.exception.EntityNotExistException;
 
 public interface PromptRepository extends JpaRepository<Prompt, Long> {
 
@@ -12,4 +13,8 @@ public interface PromptRepository extends JpaRepository<Prompt, Long> {
     List<Prompt> findByStatus(PromptStatus promptStatus);
 
     Optional<Prompt> findByMessageId(String messageId);
+
+    default Prompt getById(long id) {
+        return findById(id).orElseThrow(() -> new EntityNotExistException(Prompt.class, id));
+    }
 }

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/tag/TagRepository.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/tag/TagRepository.java
@@ -7,4 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface TagRepository extends JpaRepository<Tag, Long> {
 
     Optional<Tag> findByUuid(UUID uuid);
+
+    default Tags findAllToFirstClass() {
+        return new Tags(findAll());
+    }
 }

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/tag/Tags.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/tag/Tags.java
@@ -1,0 +1,18 @@
+package youngsu5582.tool.ai_tracker.domain.tag;
+
+import java.util.List;
+import java.util.Optional;
+
+public record Tags(List<Tag> tags) {
+
+    public Optional<Tag> findTag(String name) {
+        return tags.stream()
+            .filter(t -> t.getName().equals(name))
+            .findFirst();
+    }
+
+    public List<String> tagNames() {
+        return tags.stream().map(Tag::getName).toList();
+    }
+
+}

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/tag/Tags.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/tag/Tags.java
@@ -2,10 +2,14 @@ package youngsu5582.tool.ai_tracker.domain.tag;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.util.StringUtils;
 
 public record Tags(List<Tag> tags) {
 
     public Optional<Tag> findTag(String name) {
+        if(!StringUtils.hasText(name)) {
+            return Optional.empty();
+        }
         return tags.stream()
             .filter(t -> t.getName().equals(name))
             .findFirst();

--- a/backend/src/test/java/youngsu5582/tool/ai_tracker/domain/category/CategoriesTests.java
+++ b/backend/src/test/java/youngsu5582/tool/ai_tracker/domain/category/CategoriesTests.java
@@ -1,0 +1,41 @@
+package youngsu5582.tool.ai_tracker.domain.category;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import youngsu5582.tool.ai_tracker.MockEntityFactory;
+
+class CategoriesTests {
+
+    Categories categories;
+
+    Category category1;
+    Category category2;
+
+    @BeforeEach
+    void setUp() {
+        category1 = MockEntityFactory.createCategory("카테고리1");
+        category2 = MockEntityFactory.createCategory("카테고리2");
+        categories = new Categories(
+            List.of(category1, category2)
+        );
+    }
+
+    @Test
+    @DisplayName("카테고리를 이름으로 찾는다")
+    void findTag() {
+        var findCategory = categories.findCategory("카테고리1");
+        assertThat(findCategory).isPresent().get().isEqualTo(category1);
+    }
+
+
+    @Test
+    @DisplayName("이름에 해당하는 카테고리가 없으면 optional 을 반환한다")
+    void findTagWithNotExistName() {
+        var findCategory = categories.findCategory("없는 카테고리");
+        assertThat(findCategory).isEmpty();
+    }
+}

--- a/backend/src/test/java/youngsu5582/tool/ai_tracker/domain/category/CategoriesTests.java
+++ b/backend/src/test/java/youngsu5582/tool/ai_tracker/domain/category/CategoriesTests.java
@@ -28,7 +28,7 @@ class CategoriesTests {
     @DisplayName("카테고리를 이름으로 찾는다")
     void findTag() {
         var findCategory = categories.findCategory("카테고리1");
-        assertThat(findCategory).isPresent().get().isEqualTo(category1);
+        assertThat(findCategory).hasValue(category1);
     }
 
 

--- a/backend/src/test/java/youngsu5582/tool/ai_tracker/domain/tag/TagsTests.java
+++ b/backend/src/test/java/youngsu5582/tool/ai_tracker/domain/tag/TagsTests.java
@@ -28,7 +28,7 @@ class TagsTests {
     @DisplayName("태그를 이름으로 찾는다")
     void findTag() {
         var findTag = tags.findTag("태그1");
-        assertThat(findTag).isPresent().get().isEqualTo(tag1);
+        assertThat(findTag).hasValue(tag1);
     }
 
 

--- a/backend/src/test/java/youngsu5582/tool/ai_tracker/domain/tag/TagsTests.java
+++ b/backend/src/test/java/youngsu5582/tool/ai_tracker/domain/tag/TagsTests.java
@@ -1,0 +1,41 @@
+package youngsu5582.tool.ai_tracker.domain.tag;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import youngsu5582.tool.ai_tracker.MockEntityFactory;
+
+class TagsTests {
+
+    private Tags tags;
+
+    private Tag tag1;
+    private Tag tag2;
+
+    @BeforeEach
+    void setUp() {
+        tag1 = MockEntityFactory.createTag("태그1");
+        tag2 = MockEntityFactory.createTag("태그2");
+        tags = new Tags(
+            List.of(tag1, tag2)
+        );
+    }
+
+    @Test
+    @DisplayName("태그를 이름으로 찾는다")
+    void findTag() {
+        var findTag = tags.findTag("태그1");
+        assertThat(findTag).isPresent().get().isEqualTo(tag1);
+    }
+
+
+    @Test
+    @DisplayName("이름에 해당하는 태그가 없으면 optional 을 반환한다")
+    void findTagWithNotExistName() {
+        var findTag = tags.findTag("없는 태그");
+        assertThat(findTag).isEmpty();
+    }
+}

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,39 @@
+## 📝 Related Task
+
+- Closes #task-005
+
+## 📄 Description
+
+`DATA_ARCHITECTURE.md`에 정의된 핵심 데이터 모델인 `Prompt` 엔티티와, 데이터베이스 상호작용을 위한 `PromptRepository`를 TDD(Test-Driven Development) 방식으로 구현했습니다.
+
+이는 우리 시스템 데이터 모델의 가장 기본이 되는 뼈대를 구축하는 작업이며, 향후 모든 프롬프트 관련 데이터 처리는 이 모델을 기반으로 이루어집니다.
+
+## ✨ Key Changes
+
+이번 PR의 주요 변경 사항은 다음과 같습니다.
+
+- **`PromptStatus` Enum 정의**: 프롬프트의 상태(`RECEIVED`, `ANALYZING`, `COMPLETED`, `FAILED`)를 관리하기 위한 Enum 타입을 추가했습니다.
+- **`Prompt` 엔티티 구현**:
+    - `@Entity`를 사용하여 `prompts` 테이블과 매핑했습니다.
+    - Primary Key로 `UUID`를 사용하도록 `@GeneratedValue(strategy = GenerationType.UUID)`를 적용했습니다.
+    - 비정형 데이터를 유연하게 다루기 위해 `payload` 필드를 PostgreSQL의 `JSONB` 타입과 매핑했습니다. (`@JdbcTypeCode(SqlTypes.JSON)`)
+    - 생성/수정 시간을 자동으로 기록하기 위해 `@EntityListeners(AuditingEntityListener.class)`를 적용했습니다.
+- **`PromptRepository` 인터페이스 생성**: Spring Data JPA의 `JpaRepository<Prompt, UUID>`를 상속받아 기본적인 CRUD 기능을 확보했습니다.
+- **TDD 기반 통합 테스트 작성**:
+    - `PromptRepositoryTest`를 작성하여 TDD 사이클을 준수했습니다.
+    - `Testcontainers` 환경에서 실제 PostgreSQL 데이터베이스를 대상으로 엔티티의 저장 및 조회 기능이 올바르게 동작하는지 검증했습니다.
+
+## 🤖 To Reviewers (especially AI CodeRabbit)
+
+리뷰 시 아래 사항들을 중점적으로 확인해 주시면 감사하겠습니다.
+
+- **JPA Annotation Correctness**: `Prompt` 엔티티에 적용된 JPA 어노테이션(`@Id`, `@GeneratedValue`, `@Column`, `@JdbcTypeCode` 등)이 의도에 맞게 정확히 사용되었는지 확인 부탁드립니다.
+- **TDD Principle**: 테스트 코드(`PromptRepositoryTest`)가 실제 구현 코드보다 먼저 개념적으로 정의되고, 구현을 검증하는 역할을 충실히 수행하는지 확인 부탁드립니다.
+- **Immutability & Encapsulation**: 엔티티의 필드들이 불필요하게 외부로 노출되거나 변경 가능하지 않은지, 객체지향 원칙에 따라 잘 캡슐화되었는지 검토 부탁드립니다.
+
+## ✅ Checklist
+
+- [x] 제 코드에 대한 자체 리뷰를 수행했습니다.
+- [x] 이 프로젝트의 스타일 가이드라인을 따랐습니다.
+- [x] 변경 사항에 대한 테스트 코드를 작성했습니다.
+- [x] 모든 신규 및 기존 테스트를 통과했습니다.


### PR DESCRIPTION
### 📝 Related Task
- N/A

### 📄 Description
도메인 모델의 안정성과 확장성을 개선하고, 프로젝트의 PR 가이드라인을 문서화합니다.

### ✨ Key Changes
- **Prompt**: 분석 실패 시 에러 메시지를 저장할 `error` 컬럼을 추가했습니다.
- **PromptRepository**: `getById` 디폴트 메서드를 추가하여, ID로 조회 실패 시 `EntityNotExistException`을 발생시키도록 로직을 개선했습니다.
- ** 일급 컬렉션**: `Tag`, `Category`를 각각 `Tags`, `Categories` 일급 컬렉션으로 래핑하여 관련 비즈니스 로직의 캡슐화를 강화했습니다.
- **AttributeConverter**: `PromptProvider` Enum이 DB에 이름 대신 별칭(alias)으로 저장되도록 `AttributeConverter`를 적용했습니다.
- **Docs**: `GEMINI.MD`에 Pull Request 생성 가이드라인을 추가했습니다.

### 🤖 To Reviewers
- 도메인 모델 변경 사항, 특히 `AttributeConverter` 구현이 올바른지 확인 부탁드립니다.
- 일급 컬렉션 도입으로 인한 구조 변경이 적절한지 검토해주세요.

### ✅ Checklist
- [x] PR 제목은 Conventional Commit Convention을 따랐습니다.
- [x] 관련 없는 코드를 포함하지 않았습니다.
- [x] 테스트 코드를 작성했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Searchable Categories and Tags with collection helpers
  * Prompts can be assigned a category, marked completed or failed, and support batch tag additions
  * Provider identifiers now use standardized aliases for clearer serialization

* **Improvements**
  * Clearer error reporting when requested entities are missing

* **Documentation**
  * Added PR creation guidelines with templates and reviewer checklist

* **Tests**
  * Unit tests added for category and tag lookup behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->