### PR TITLE
feat: 프롬프트 분석 및 결과 저장 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -22,9 +22,29 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven { url 'https://repo.spring.io/milestone' }
+    maven { url 'https://repo.spring.io/snapshot' }
+    maven {
+        name = 'Central Portal Snapshots'
+        url = 'https://central.sonatype.com/repository/maven-snapshots/'
+    }
+}
+
+ext {
+    set('springAiVersion', "1.0.0")
+}
+
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.ai:spring-ai-bom:${springAiVersion}"
+    }
 }
 
 dependencies {
+    // Replace the following with the starter dependencies of specific modules you wish to use
+    implementation 'org.springframework.ai:spring-ai-starter-model-openai'
+
     // Web
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -41,7 +61,8 @@ dependencies {
 
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.boot:spring-boot-testcontainers' // For @ServiceConnection
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    // For @ServiceConnection
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:postgresql'
     testImplementation 'org.awaitility:awaitility:4.2.1'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -31,7 +31,7 @@ repositories {
 }
 
 ext {
-    set('springAiVersion', "1.0.0")
+    set('springAiVersion', "1.0.1")
 }
 
 

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/application/service/AnalysisService.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/application/service/AnalysisService.java
@@ -1,7 +1,5 @@
 package youngsu5582.tool.ai_tracker.application.service;
 
-import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -24,6 +22,9 @@ import youngsu5582.tool.ai_tracker.provider.dto.AnalysisMetadata;
 import youngsu5582.tool.ai_tracker.provider.dto.AnalysisMetadata.AnalysisMetadataAttribute;
 import youngsu5582.tool.ai_tracker.provider.dto.AnalysisResult;
 
+import java.util.List;
+import java.util.Map;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -38,7 +39,7 @@ public class AnalysisService {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Async
     public void analysis(PromptReceivedEvent event) {
-        Prompt prompt = promptRepository.getById(event.promptId());
+        Prompt prompt = promptRepository.getByIdOrThrow(event.promptId());
         Categories categories = categoryRepository.findAllToFirstClass();
         Tags tags = tagRepository.findAllToFirstClass();
 

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/application/service/AnalysisService.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/application/service/AnalysisService.java
@@ -1,0 +1,94 @@
+package youngsu5582.tool.ai_tracker.application.service;
+
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import youngsu5582.tool.ai_tracker.application.event.PromptReceivedEvent;
+import youngsu5582.tool.ai_tracker.domain.category.Categories;
+import youngsu5582.tool.ai_tracker.domain.category.Category;
+import youngsu5582.tool.ai_tracker.domain.category.CategoryRepository;
+import youngsu5582.tool.ai_tracker.domain.prompt.Prompt;
+import youngsu5582.tool.ai_tracker.domain.prompt.PromptRepository;
+import youngsu5582.tool.ai_tracker.domain.tag.Tag;
+import youngsu5582.tool.ai_tracker.domain.tag.TagRepository;
+import youngsu5582.tool.ai_tracker.domain.tag.Tags;
+import youngsu5582.tool.ai_tracker.provider.PromptAnalysisProvider;
+import youngsu5582.tool.ai_tracker.provider.dto.AnalysisMetadata;
+import youngsu5582.tool.ai_tracker.provider.dto.AnalysisMetadata.AnalysisMetadataAttribute;
+import youngsu5582.tool.ai_tracker.provider.dto.AnalysisResult;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AnalysisService {
+
+    private final PromptRepository promptRepository;
+    private final TagRepository tagRepository;
+    private final CategoryRepository categoryRepository;
+    private final PromptAnalysisProvider promptAnalysisProvider;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Async
+    public void analysis(PromptReceivedEvent event) {
+        Prompt prompt = promptRepository.getById(event.promptId());
+        Categories categories = categoryRepository.findAllToFirstClass();
+        Tags tags = tagRepository.findAllToFirstClass();
+
+        try {
+            // DB 에서 필요한 요소들 조회
+            log.info("프롬프트 분석을 시작합니다. ID: {}", event.promptId());
+
+            AnalysisMetadata metadata = new AnalysisMetadata(
+                Map.of(AnalysisMetadataAttribute.CATEGORY_LIST, categories.categoryNames(),
+                    AnalysisMetadataAttribute.TAG_LIST, tags.tagNames()
+                )
+            );
+
+            // 프롬프트 분석한 결과
+            AnalysisResult result = promptAnalysisProvider.analyze(prompt.getPayload(), metadata);
+            log.info("분석한 응답: {}", result);
+
+            // 데이터 설정
+            Category promptCategory = findOrSaveCategory(categories, result.category(),
+                result.parentCategory());
+            List<Tag> promptTags = result.tagList()
+                .stream().map(tag -> findOrSaveTag(tags, tag))
+                .toList();
+            prompt.completeAnalyze(promptCategory, promptTags);
+
+            log.info("프롬프트 분석을 완료했습니다. ID: {}, 카테고리: {}, 태그 목록: {}", event.promptId(),
+                promptCategory, promptTags);
+        } catch (Exception e) {
+            log.warn("프롬프트 분석을 실패했습니다! ID: {} 메시지: {}", event.promptId(), e.getMessage(), e);
+            prompt.failAnalyze(e.getMessage());
+        }
+    }
+
+    private Tag findOrSaveTag(Tags tags, String tagName) {
+        return tags.findTag(tagName)
+            .orElseGet(() -> tagRepository.save(Tag.builder().name(tagName).build()));
+    }
+
+    // 카테고리는 태그와 다소 다르다...
+    // 왜냐하면, 부모 카테고리라는 개념이 존재 - AI 한테 묻고, 정보를 받아와야 함
+    // 부모 개념이 존재하는거 같다면? -> AI 한테 받아오게
+    private Category findOrSaveCategory(Categories categories,
+        String categoryName,
+        String parentCategoryName) {
+        Category parentCategory = categories.findCategory(parentCategoryName).orElse(null);
+        return categories.findCategory(categoryName)
+            .orElseGet(
+                () -> categoryRepository.save(Category.builder()
+                    .name(categoryName)
+                    .parentCategory(parentCategory)
+                    .build()));
+    }
+}

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/application/service/IngestionService.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/application/service/IngestionService.java
@@ -24,6 +24,7 @@ public class IngestionService {
     public UUID accept(CaptureRequest captureRequest) {
         log.info("Accepting capture request with messageId: {}", captureRequest.getId());
         Prompt prompt = findOrSavePrompt(captureRequest);
+        log.info("프롬프트를 저장했습니다. ID: {} 페이로드: {}", prompt.getId(), prompt.getPayload());
         applicationEventPublisher.publishEvent(new PromptReceivedEvent(prompt.getId()));
         return prompt.getUuid();
     }

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/application/service/IngestionService.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/application/service/IngestionService.java
@@ -1,6 +1,5 @@
 package youngsu5582.tool.ai_tracker.application.service;
 
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -11,6 +10,8 @@ import youngsu5582.tool.ai_tracker.domain.prompt.Prompt;
 import youngsu5582.tool.ai_tracker.domain.prompt.PromptRepository;
 import youngsu5582.tool.ai_tracker.domain.prompt.PromptStatus;
 import youngsu5582.tool.ai_tracker.presentation.api.dto.CaptureRequest;
+
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -24,17 +25,18 @@ public class IngestionService {
     public UUID accept(CaptureRequest captureRequest) {
         log.info("Accepting capture request with messageId: {}", captureRequest.getId());
         Prompt prompt = findOrSavePrompt(captureRequest);
-        log.info("프롬프트를 저장했습니다. ID: {} 페이로드: {}", prompt.getId(), prompt.getPayload());
+        log.info("Prompt saved successfully. ID: {}, payload length: {}", prompt.getId(),
+                prompt.getPayload() != null ? prompt.getPayload().length() : 0);
         applicationEventPublisher.publishEvent(new PromptReceivedEvent(prompt.getId()));
         return prompt.getUuid();
     }
 
     private Prompt findOrSavePrompt(CaptureRequest captureRequest) {
         Prompt prompt = promptRepository.findByMessageId(captureRequest.getId())
-            .orElseGet(() -> promptRepository.save(Prompt.builder()
-                .status(PromptStatus.RECEIVED)
-                .messageId(captureRequest.getId())
-                .build()));
+                .orElseGet(() -> promptRepository.save(Prompt.builder()
+                        .status(PromptStatus.RECEIVED)
+                        .messageId(captureRequest.getId())
+                        .build()));
         prompt.updatePayload(captureRequest.getPayload());
         return prompt;
     }

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/prompt/PromptRepository.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/prompt/PromptRepository.java
@@ -1,10 +1,11 @@
 package youngsu5582.tool.ai_tracker.domain.prompt;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+import youngsu5582.tool.ai_tracker.common.exception.EntityNotExistException;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.jpa.repository.JpaRepository;
-import youngsu5582.tool.ai_tracker.common.exception.EntityNotExistException;
 
 public interface PromptRepository extends JpaRepository<Prompt, Long> {
 
@@ -14,7 +15,7 @@ public interface PromptRepository extends JpaRepository<Prompt, Long> {
 
     Optional<Prompt> findByMessageId(String messageId);
 
-    default Prompt getById(long id) {
+    default Prompt getByIdOrThrow(long id) {
         return findById(id).orElseThrow(() -> new EntityNotExistException(Prompt.class, id));
     }
 }

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/presentation/api/DataController.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/presentation/api/DataController.java
@@ -23,7 +23,8 @@ public class DataController {
 
     @PostMapping(value = "/api/v1/prompts", consumes = APPLICATION_JSON_VALUE)
     public ResponseEntity<CaptureResponse> prompts(@Valid @RequestBody CaptureRequest request) {
-        log.info("요청 수신 {}", request);
+        log.info("요청 수신 ID: {}, 대화 ID: {}, Metadata: {}", request.getId(),
+            request.getConversationId(), request.getMetadata());
         UUID uuid = ingestionService.accept(request);
         return ResponseEntity.accepted().body(new CaptureResponse(uuid));
     }

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/presentation/api/DataController.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/presentation/api/DataController.java
@@ -1,9 +1,6 @@
 package youngsu5582.tool.ai_tracker.presentation.api;
 
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-
 import jakarta.validation.Valid;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +11,10 @@ import youngsu5582.tool.ai_tracker.application.service.IngestionService;
 import youngsu5582.tool.ai_tracker.presentation.api.dto.CaptureRequest;
 import youngsu5582.tool.ai_tracker.presentation.api.dto.CaptureResponse;
 
+import java.util.UUID;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -23,8 +24,8 @@ public class DataController {
 
     @PostMapping(value = "/api/v1/prompts", consumes = APPLICATION_JSON_VALUE)
     public ResponseEntity<CaptureResponse> prompts(@Valid @RequestBody CaptureRequest request) {
-        log.info("요청 수신 ID: {}, 대화 ID: {}, Metadata: {}", request.getId(),
-            request.getConversationId(), request.getMetadata());
+        log.debug("Request metadata: {}", request.getMetadata());
+        log.info("Request received. ID: {}, conversationId: {}", request.getId(), request.getConversationId());
         UUID uuid = ingestionService.accept(request);
         return ResponseEntity.accepted().body(new CaptureResponse(uuid));
     }

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/provider/FakePromptAnalysisProvider.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/provider/FakePromptAnalysisProvider.java
@@ -1,0 +1,31 @@
+package youngsu5582.tool.ai_tracker.provider;
+
+import jakarta.annotation.PostConstruct;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.stereotype.Component;
+import youngsu5582.tool.ai_tracker.provider.dto.AnalysisMetadata;
+import youngsu5582.tool.ai_tracker.provider.dto.AnalysisResult;
+
+@Slf4j
+@Component
+@ConditionalOnMissingBean(PromptAnalysisProvider.class)
+public class FakePromptAnalysisProvider implements PromptAnalysisProvider {
+
+    @PostConstruct
+    public void init() {
+        log.info("확인용 FAKE 프롬프트 분석이 활성화되었습니다.");
+    }
+
+    @Override
+    public AnalysisResult analyze(String payload, AnalysisMetadata analysisMetadata) {
+        log.warn("[FAKE] 프롬프트 분석을 진행합니다. OpenAI API Key가 설정되지 않았습니다.");
+        return AnalysisResult
+            .builder()
+            .category("Uncategorized")
+            .parentCategory("None")
+            .tagList(List.of("fake-analysis"))
+            .build();
+    }
+}

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/provider/FakePromptAnalysisProvider.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/provider/FakePromptAnalysisProvider.java
@@ -1,16 +1,17 @@
 package youngsu5582.tool.ai_tracker.provider;
 
 import jakarta.annotation.PostConstruct;
-import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.stereotype.Component;
 import youngsu5582.tool.ai_tracker.provider.dto.AnalysisMetadata;
 import youngsu5582.tool.ai_tracker.provider.dto.AnalysisResult;
 
+import java.util.List;
+
 @Slf4j
 @Component
-@ConditionalOnMissingBean(PromptAnalysisProvider.class)
+@ConditionalOnMissingBean(OpenAiPromptAnalysisProvider.class)
 public class FakePromptAnalysisProvider implements PromptAnalysisProvider {
 
     @PostConstruct

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/provider/OpenAiPromptAnalysisProvider.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/provider/OpenAiPromptAnalysisProvider.java
@@ -1,0 +1,116 @@
+package youngsu5582.tool.ai_tracker.provider;
+
+import jakarta.annotation.PostConstruct;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.chat.prompt.PromptTemplate;
+import org.springframework.ai.converter.BeanOutputConverter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import youngsu5582.tool.ai_tracker.provider.dto.AnalysisMetadata;
+import youngsu5582.tool.ai_tracker.provider.dto.AnalysisResult;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(name = "spring.ai.openai.api-key")
+public class OpenAiPromptAnalysisProvider implements PromptAnalysisProvider {
+
+    private final ChatClient chatClient;
+
+    @PostConstruct
+    public void init() {
+        log.info("Open AI 프롬프트 분석이 활성화되었습니다!");
+    }
+
+    public OpenAiPromptAnalysisProvider(ChatClient.Builder chatClientBuilder) {
+        this.chatClient = chatClientBuilder.build();
+    }
+
+    private static final String SYSTEM_PROMPT = """
+        당신은 사용자의 프롬프트 내용을 분석하여 적절한 카테고리와 태그를 추천해주는 전문 AI 어시스턴트입니다.
+
+        분석의 정확도를 높이기 위해, 현재 시스템에 존재하는 카테고리 및 태그 목록을 제공합니다.
+        - EXISTING_CATEGORIES: [{existing_categories}]
+        - EXISTING_TAGS: [{existing_tags}]
+
+        ## 중요 규칙
+        1. **카테고리 선택**: 먼저, 프롬프트 내용에 가장 적합한 카테고리를 `EXISTING_CATEGORIES` 목록에서 찾아보세요. 만약 적절한 것이 있다면 해당 카테고리 이름을 `category` 값으로 사용하세요. 적절한 것이 없다면, 주제에 맞는 새로운 카테고리 이름을 생성하세요.
+        2. **태그 선택**: `tagList`를 생성할 때, `EXISTING_TAGS` 목록에 있는 태그가 내용과 관련 있다면 최대한 재사용해주세요. 물론, 필요하다면 목록에 없는 새로운 태그를 추가하는 것도 좋습니다. 기존 태그와 새로운 태그를 조합할 수 있습니다.
+        3. **상위 카테고리**: `parentCategory`는 `category`의 상위 개념으로 'EXISTING_CATEGORIES' 또는 주제에 맞는 새로운 카테고리를 생성하세요.
+
+        결과는 반드시 다음 JSON 형식으로만 응답해야 합니다:
+        {format}
+        """;
+
+    private static final String USER_PROMPT = """
+        다음 프롬프트 내용을 분석해주세요:
+        ---
+        {payload}
+        ---
+        """;
+
+    /**
+     * 인지한 에러 목록
+     * <p>
+     * org.springframework.ai.retry.NonTransientAiException: HTTP 401 - { "error": { "message":
+     * "Incorrect API key provided:
+     * sk-proj-***************************************************************cYkC. You can find
+     * your API key at https://platform.openai.com/account/api-keys.", "type":
+     * "invalid_request_error", "param": null, "code": "invalid_api_key" } }
+     */
+    @Override
+    public AnalysisResult analyze(String payload, AnalysisMetadata analysisMetadata) {
+        // 1. AI의 응답을 AnalysisResult 클래스로 파싱하도록 설정
+        BeanOutputConverter<AnalysisResult> outputParser = new BeanOutputConverter<>(
+            AnalysisResult.class);
+
+        // 2. Metadata에서 기존 카테고리/태그 목록 추출 및 프롬프트용 문자열로 변환
+        List<String> existingCategories = analysisMetadata.getCategoryList();
+        List<String> existingTags = analysisMetadata.getTagList();
+
+        String categoriesForPrompt =
+            existingCategories.isEmpty() ? "없음" : String.join(", ", existingCategories);
+        String tagsForPrompt =
+            existingTags.isEmpty() ? "없음" : String.join(", ", existingTags);
+
+        // 3. 시스템 프롬프트에 최종 출력 포맷 및 기존 데이터 정보를 주입
+        PromptTemplate systemPromptTemplate = new PromptTemplate(SYSTEM_PROMPT);
+        Map<String, Object> systemPromptContext = Map.of(
+            "format", outputParser.getFormat(),
+            "existing_categories", categoriesForPrompt,
+            "existing_tags", tagsForPrompt
+        );
+        SystemMessage systemMessage = new SystemMessage(
+            systemPromptTemplate.render(systemPromptContext));
+
+        // 4. 사용자 프롬프트 생성
+        PromptTemplate userPromptTemplate = new PromptTemplate(USER_PROMPT);
+        UserMessage userMessage = new UserMessage(
+            userPromptTemplate.render(Map.of("payload", payload)));
+
+        // 5. 시스템/사용자 프롬프트를 합쳐 최종 프롬프트 생성
+        Prompt finalPrompt = new Prompt(List.of(systemMessage, userMessage));
+
+        log.info("[OpenAI] 프롬프트 분석을 요청합니다.");
+
+        // 6. AI 호출 및 결과 파싱
+        String responseContent = chatClient.prompt(finalPrompt).call()
+            .content();
+
+        assert responseContent != null;
+
+        AnalysisResult analysisResult = outputParser.convert(responseContent);
+
+        log.info("[OpenAI] 프롬프트 분석 완료. Category: {}(부모 Category: {}), Tags: {}",
+            analysisResult.category(),
+            analysisResult.parentCategory(),
+            analysisResult.tagList());
+
+        return analysisResult;
+    }
+}

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/provider/OpenAiPromptAnalysisProvider.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/provider/OpenAiPromptAnalysisProvider.java
@@ -1,8 +1,6 @@
 package youngsu5582.tool.ai_tracker.provider;
 
 import jakarta.annotation.PostConstruct;
-import java.util.List;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.messages.SystemMessage;
@@ -12,8 +10,12 @@ import org.springframework.ai.chat.prompt.PromptTemplate;
 import org.springframework.ai.converter.BeanOutputConverter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import youngsu5582.tool.ai_tracker.provider.dto.AnalysisMetadata;
 import youngsu5582.tool.ai_tracker.provider.dto.AnalysisResult;
+
+import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Component
@@ -24,7 +26,7 @@ public class OpenAiPromptAnalysisProvider implements PromptAnalysisProvider {
 
     @PostConstruct
     public void init() {
-        log.info("Open AI 프롬프트 분석이 활성화되었습니다!");
+        log.info("[OpenAI] Requesting analysis.");
     }
 
     public OpenAiPromptAnalysisProvider(ChatClient.Builder chatClientBuilder) {
@@ -32,27 +34,27 @@ public class OpenAiPromptAnalysisProvider implements PromptAnalysisProvider {
     }
 
     private static final String SYSTEM_PROMPT = """
-        당신은 사용자의 프롬프트 내용을 분석하여 적절한 카테고리와 태그를 추천해주는 전문 AI 어시스턴트입니다.
-
-        분석의 정확도를 높이기 위해, 현재 시스템에 존재하는 카테고리 및 태그 목록을 제공합니다.
-        - EXISTING_CATEGORIES: [{existing_categories}]
-        - EXISTING_TAGS: [{existing_tags}]
-
-        ## 중요 규칙
-        1. **카테고리 선택**: 먼저, 프롬프트 내용에 가장 적합한 카테고리를 `EXISTING_CATEGORIES` 목록에서 찾아보세요. 만약 적절한 것이 있다면 해당 카테고리 이름을 `category` 값으로 사용하세요. 적절한 것이 없다면, 주제에 맞는 새로운 카테고리 이름을 생성하세요.
-        2. **태그 선택**: `tagList`를 생성할 때, `EXISTING_TAGS` 목록에 있는 태그가 내용과 관련 있다면 최대한 재사용해주세요. 물론, 필요하다면 목록에 없는 새로운 태그를 추가하는 것도 좋습니다. 기존 태그와 새로운 태그를 조합할 수 있습니다.
-        3. **상위 카테고리**: `parentCategory`는 `category`의 상위 개념으로 'EXISTING_CATEGORIES' 또는 주제에 맞는 새로운 카테고리를 생성하세요.
-
-        결과는 반드시 다음 JSON 형식으로만 응답해야 합니다:
-        {format}
-        """;
+            당신은 사용자의 프롬프트 내용을 분석하여 적절한 카테고리와 태그를 추천해주는 전문 AI 어시스턴트입니다.
+            
+            분석의 정확도를 높이기 위해, 현재 시스템에 존재하는 카테고리 및 태그 목록을 제공합니다.
+            - EXISTING_CATEGORIES: [{existing_categories}]
+            - EXISTING_TAGS: [{existing_tags}]
+            
+            ## 중요 규칙
+            1. **카테고리 선택**: 먼저, 프롬프트 내용에 가장 적합한 카테고리를 `EXISTING_CATEGORIES` 목록에서 찾아보세요. 만약 적절한 것이 있다면 해당 카테고리 이름을 `category` 값으로 사용하세요. 적절한 것이 없다면, 주제에 맞는 새로운 카테고리 이름을 생성하세요.
+            2. **태그 선택**: `tagList`를 생성할 때, `EXISTING_TAGS` 목록에 있는 태그가 내용과 관련 있다면 최대한 재사용해주세요. 물론, 필요하다면 목록에 없는 새로운 태그를 추가하는 것도 좋습니다. 기존 태그와 새로운 태그를 조합할 수 있습니다.
+            3. **상위 카테고리**: `parentCategory`는 `category`의 상위 개념으로 'EXISTING_CATEGORIES' 또는 주제에 맞는 새로운 카테고리를 생성하세요.
+            
+            결과는 반드시 다음 JSON 형식으로만 응답해야 합니다:
+            {format}
+            """;
 
     private static final String USER_PROMPT = """
-        다음 프롬프트 내용을 분석해주세요:
-        ---
-        {payload}
-        ---
-        """;
+            다음 프롬프트 내용을 분석해주세요:
+            ---
+            {payload}
+            ---
+            """;
 
     /**
      * 인지한 에러 목록
@@ -67,31 +69,31 @@ public class OpenAiPromptAnalysisProvider implements PromptAnalysisProvider {
     public AnalysisResult analyze(String payload, AnalysisMetadata analysisMetadata) {
         // 1. AI의 응답을 AnalysisResult 클래스로 파싱하도록 설정
         BeanOutputConverter<AnalysisResult> outputParser = new BeanOutputConverter<>(
-            AnalysisResult.class);
+                AnalysisResult.class);
 
         // 2. Metadata에서 기존 카테고리/태그 목록 추출 및 프롬프트용 문자열로 변환
         List<String> existingCategories = analysisMetadata.getCategoryList();
         List<String> existingTags = analysisMetadata.getTagList();
 
         String categoriesForPrompt =
-            existingCategories.isEmpty() ? "없음" : String.join(", ", existingCategories);
+                existingCategories.isEmpty() ? "없음" : String.join(", ", existingCategories);
         String tagsForPrompt =
-            existingTags.isEmpty() ? "없음" : String.join(", ", existingTags);
+                existingTags.isEmpty() ? "없음" : String.join(", ", existingTags);
 
         // 3. 시스템 프롬프트에 최종 출력 포맷 및 기존 데이터 정보를 주입
         PromptTemplate systemPromptTemplate = new PromptTemplate(SYSTEM_PROMPT);
         Map<String, Object> systemPromptContext = Map.of(
-            "format", outputParser.getFormat(),
-            "existing_categories", categoriesForPrompt,
-            "existing_tags", tagsForPrompt
+                "format", outputParser.getFormat(),
+                "existing_categories", categoriesForPrompt,
+                "existing_tags", tagsForPrompt
         );
         SystemMessage systemMessage = new SystemMessage(
-            systemPromptTemplate.render(systemPromptContext));
+                systemPromptTemplate.render(systemPromptContext));
 
         // 4. 사용자 프롬프트 생성
         PromptTemplate userPromptTemplate = new PromptTemplate(USER_PROMPT);
         UserMessage userMessage = new UserMessage(
-            userPromptTemplate.render(Map.of("payload", payload)));
+                userPromptTemplate.render(Map.of("payload", payload)));
 
         // 5. 시스템/사용자 프롬프트를 합쳐 최종 프롬프트 생성
         Prompt finalPrompt = new Prompt(List.of(systemMessage, userMessage));
@@ -100,16 +102,17 @@ public class OpenAiPromptAnalysisProvider implements PromptAnalysisProvider {
 
         // 6. AI 호출 및 결과 파싱
         String responseContent = chatClient.prompt(finalPrompt).call()
-            .content();
+                .content();
 
-        assert responseContent != null;
-
+        if (!StringUtils.hasText(responseContent)) {
+            throw new IllegalStateException("OpenAI returned null response content");
+        }
         AnalysisResult analysisResult = outputParser.convert(responseContent);
 
-        log.info("[OpenAI] 프롬프트 분석 완료. Category: {}(부모 Category: {}), Tags: {}",
-            analysisResult.category(),
-            analysisResult.parentCategory(),
-            analysisResult.tagList());
+        log.info("[OpenAI] Analysis completed. category={} parentCategory={} tags={}",
+                analysisResult.category(),
+                analysisResult.parentCategory(),
+                analysisResult.tagList());
 
         return analysisResult;
     }

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/provider/PromptAnalysisProvider.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/provider/PromptAnalysisProvider.java
@@ -1,0 +1,12 @@
+package youngsu5582.tool.ai_tracker.provider;
+
+import youngsu5582.tool.ai_tracker.provider.dto.AnalysisMetadata;
+import youngsu5582.tool.ai_tracker.provider.dto.AnalysisResult;
+
+/**
+ * Prompt 를 분석해서 결과를 제공해주는 제공자
+ */
+public interface PromptAnalysisProvider {
+
+    AnalysisResult analyze(String payload, AnalysisMetadata analysisMetadata);
+}

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/provider/dto/AnalysisMetadata.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/provider/dto/AnalysisMetadata.java
@@ -1,0 +1,25 @@
+package youngsu5582.tool.ai_tracker.provider.dto;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 더 유의미한 분석을 하기 위해 제공되는 속성
+ */
+public record AnalysisMetadata(
+    Map<AnalysisMetadataAttribute, List<String>> data
+) {
+
+    public enum AnalysisMetadataAttribute {
+        CATEGORY_LIST,
+        TAG_LIST
+    }
+
+    public List<String> getCategoryList() {
+        return data.getOrDefault(AnalysisMetadataAttribute.CATEGORY_LIST, List.of());
+    }
+
+    public List<String> getTagList() {
+        return data.getOrDefault(AnalysisMetadataAttribute.TAG_LIST, List.of());
+    }
+}

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/provider/dto/AnalysisResult.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/provider/dto/AnalysisResult.java
@@ -1,0 +1,15 @@
+package youngsu5582.tool.ai_tracker.provider.dto;
+
+import java.util.List;
+import lombok.Builder;
+import org.springframework.lang.Nullable;
+
+@Builder
+public record AnalysisResult(
+    String category,
+
+    @Nullable String parentCategory,
+    List<String> tagList
+) {
+
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,10 @@
+spring:
+  ai:
+    retry:
+      max-attempts: 3
+    openai:
+      api-key: ${OPENAI_API_KEY}
+      chat:
+        options:
+          model: gpt-4-turbo-preview
+          temperature: 0.2

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -2,6 +2,10 @@ spring:
   ai:
     retry:
       max-attempts: 3
+      backoff:
+        initial-interval: 1s
+        multiplier: 2
+        max-interval: 10s
     openai:
       api-key: ${OPENAI_API_KEY}
       chat:

--- a/backend/src/test/java/youngsu5582/tool/ai_tracker/application/service/AnalysisServiceTests.java
+++ b/backend/src/test/java/youngsu5582/tool/ai_tracker/application/service/AnalysisServiceTests.java
@@ -1,0 +1,79 @@
+package youngsu5582.tool.ai_tracker.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import youngsu5582.tool.ai_tracker.MockEntityFactory;
+import youngsu5582.tool.ai_tracker.application.event.PromptReceivedEvent;
+import youngsu5582.tool.ai_tracker.domain.category.Category;
+import youngsu5582.tool.ai_tracker.domain.prompt.Prompt;
+import youngsu5582.tool.ai_tracker.domain.prompt.PromptStatus;
+import youngsu5582.tool.ai_tracker.domain.tag.Tag;
+import youngsu5582.tool.ai_tracker.provider.dto.AnalysisMetadata;
+import youngsu5582.tool.ai_tracker.provider.dto.AnalysisResult;
+import youngsu5582.tool.ai_tracker.support.IntegrationTestSupport;
+
+class AnalysisServiceTests extends IntegrationTestSupport {
+
+    Prompt prompt;
+
+    @BeforeEach
+    void setup() {
+        prompt = promptRepository.save(MockEntityFactory.createPrompt(PromptStatus.RECEIVED));
+    }
+
+    @Test
+    @DisplayName("분석 제공자를 통해 프롬프트를 분석해 저장한다.")
+    void analyzeCompleteAndChangeComplete() {
+        // given
+        Mockito.doReturn(AnalysisResult.builder()
+                .category("JPA")
+                .tagList(List.of("Java", "Spring"))
+                .build()).when(promptAnalysisProvider)
+            .analyze(anyString(), any(AnalysisMetadata.class));
+
+        // when
+        eventPublisher.publishEvent(new PromptReceivedEvent(prompt.getId()));
+
+        // then
+        await().untilAsserted(() -> {
+            assertThat(promptRepository.findById(prompt.getId()))
+                .isPresent()
+                .get()
+                .extracting(Prompt::getStatus)
+                .isEqualTo(PromptStatus.COMPLETED);
+        });
+        assertThat(tagRepository.findAll()).extracting(Tag::getName)
+            .containsExactly("Java", "Spring");
+
+        assertThat(categoryRepository.findAll()).extracting(Category::getName)
+            .containsExactly("JPA");
+    }
+
+    @Test
+    @DisplayName("분석에 실패하면, 실패로 변경한다")
+    void analyzeFailAndChangeFailed() {
+        // given
+        Mockito.doThrow(new RuntimeException("Something Error!")).when(promptAnalysisProvider)
+            .analyze(anyString(), any(AnalysisMetadata.class));
+
+        // when
+        eventPublisher.publishEvent(new PromptReceivedEvent(prompt.getId()));
+
+        // then
+        await().untilAsserted(() -> {
+            assertThat(promptRepository.findById(prompt.getId()))
+                .isPresent()
+                .get()
+                .extracting(Prompt::getStatus)
+                .isEqualTo(PromptStatus.FAILED);
+        });
+    }
+}

--- a/backend/src/test/java/youngsu5582/tool/ai_tracker/provider/OpenAiPromptAnalysisProviderTests.java
+++ b/backend/src/test/java/youngsu5582/tool/ai_tracker/provider/OpenAiPromptAnalysisProviderTests.java
@@ -1,0 +1,70 @@
+package youngsu5582.tool.ai_tracker.provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.prompt.Prompt;
+import youngsu5582.tool.ai_tracker.provider.dto.AnalysisMetadata;
+import youngsu5582.tool.ai_tracker.provider.dto.AnalysisMetadata.AnalysisMetadataAttribute;
+import youngsu5582.tool.ai_tracker.provider.dto.AnalysisResult;
+import youngsu5582.tool.ai_tracker.support.IntegrationTestSupport;
+
+class OpenAiPromptAnalysisProviderTests extends IntegrationTestSupport {
+
+    private ChatClient mockChatClient;
+    private OpenAiPromptAnalysisProvider openAiPromptAnalysisProvider;
+
+
+    @BeforeEach
+    void setup() {
+        mockChatClient = mock(ChatClient.class, Answers.RETURNS_DEEP_STUBS);
+        ChatClient.Builder mockBuilder = mock(ChatClient.Builder.class);
+
+        when(mockBuilder.build()).thenReturn(mockChatClient);
+        openAiPromptAnalysisProvider = new OpenAiPromptAnalysisProvider(
+            mockBuilder);
+    }
+
+    @Test
+    @DisplayName("주어진 프롬프트와 메타데이터를 사용해 OpenAI API 호출 후 결과를 올바르게 파싱한다")
+    void analyzePromptAndParseResult() {
+        // given
+        // 예상되는 AI의 응답 (JSON 형태의 문자열)을 정의
+        String expectedJson = """
+            {
+                "parentCategory": "Backend",
+                "category": "Spring Boot",
+                "tagList": ["java", "spring", "jpa"]
+            }
+            """;
+
+        // mockChatClient의 실제 호출 체인에 대해 예상 응답을 반환하도록 설정
+        when(mockChatClient.prompt(any(Prompt.class)).call().content()).thenReturn(expectedJson);
+
+        // 테스트에 사용할 입력 데이터 준비
+        String payload = "Spring Boot JPA에서 N+1 문제를 해결하는 방법에 대해 알려줘";
+        AnalysisMetadata metadata = new AnalysisMetadata(
+            Map.of(AnalysisMetadataAttribute.TAG_LIST, List.of("Java", "Spring Boot", "Database"),
+                AnalysisMetadataAttribute.CATEGORY_LIST, List.of("jpa", "querydsl", "n+1"))
+        );
+
+        // when
+        AnalysisResult actualResult = openAiPromptAnalysisProvider.analyze(payload, metadata);
+
+        // then
+        // 반환된 결과가 예상과 일치하는지 검증
+        assertThat(actualResult).isNotNull();
+        assertThat(actualResult.parentCategory()).isEqualTo("Backend");
+        assertThat(actualResult.category()).isEqualTo("Spring Boot");
+        assertThat(actualResult.tagList()).containsExactlyInAnyOrder("java", "spring", "jpa");
+    }
+}

--- a/backend/src/test/java/youngsu5582/tool/ai_tracker/provider/OpenAiPromptAnalysisProviderTests.java
+++ b/backend/src/test/java/youngsu5582/tool/ai_tracker/provider/OpenAiPromptAnalysisProviderTests.java
@@ -1,22 +1,24 @@
 package youngsu5582.tool.ai_tracker.provider;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.prompt.Prompt;
 import youngsu5582.tool.ai_tracker.provider.dto.AnalysisMetadata;
 import youngsu5582.tool.ai_tracker.provider.dto.AnalysisMetadata.AnalysisMetadataAttribute;
 import youngsu5582.tool.ai_tracker.provider.dto.AnalysisResult;
 import youngsu5582.tool.ai_tracker.support.IntegrationTestSupport;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class OpenAiPromptAnalysisProviderTests extends IntegrationTestSupport {
 
@@ -31,8 +33,11 @@ class OpenAiPromptAnalysisProviderTests extends IntegrationTestSupport {
 
         when(mockBuilder.build()).thenReturn(mockChatClient);
         openAiPromptAnalysisProvider = new OpenAiPromptAnalysisProvider(
-            mockBuilder);
+                mockBuilder);
     }
+
+    @Captor
+    private ArgumentCaptor<Prompt> promptCaptor;
 
     @Test
     @DisplayName("주어진 프롬프트와 메타데이터를 사용해 OpenAI API 호출 후 결과를 올바르게 파싱한다")
@@ -40,21 +45,21 @@ class OpenAiPromptAnalysisProviderTests extends IntegrationTestSupport {
         // given
         // 예상되는 AI의 응답 (JSON 형태의 문자열)을 정의
         String expectedJson = """
-            {
-                "parentCategory": "Backend",
-                "category": "Spring Boot",
-                "tagList": ["java", "spring", "jpa"]
-            }
-            """;
+                {
+                    "parentCategory": "Backend",
+                    "category": "Spring Boot",
+                    "tagList": ["java", "spring", "jpa"]
+                }
+                """;
 
         // mockChatClient의 실제 호출 체인에 대해 예상 응답을 반환하도록 설정
-        when(mockChatClient.prompt(any(Prompt.class)).call().content()).thenReturn(expectedJson);
+        when(mockChatClient.prompt(promptCaptor.capture()).call().content()).thenReturn(expectedJson);
 
         // 테스트에 사용할 입력 데이터 준비
         String payload = "Spring Boot JPA에서 N+1 문제를 해결하는 방법에 대해 알려줘";
         AnalysisMetadata metadata = new AnalysisMetadata(
-            Map.of(AnalysisMetadataAttribute.TAG_LIST, List.of("Java", "Spring Boot", "Database"),
-                AnalysisMetadataAttribute.CATEGORY_LIST, List.of("jpa", "querydsl", "n+1"))
+                Map.of(AnalysisMetadataAttribute.TAG_LIST, List.of("Java", "Spring Boot", "Database"),
+                        AnalysisMetadataAttribute.CATEGORY_LIST, List.of("jpa", "querydsl", "n+1"))
         );
 
         // when
@@ -66,5 +71,10 @@ class OpenAiPromptAnalysisProviderTests extends IntegrationTestSupport {
         assertThat(actualResult.parentCategory()).isEqualTo("Backend");
         assertThat(actualResult.category()).isEqualTo("Spring Boot");
         assertThat(actualResult.tagList()).containsExactlyInAnyOrder("java", "spring", "jpa");
+
+        Prompt capturedPrompt = promptCaptor.getValue();
+        String promptContent = capturedPrompt.getContents();
+        assertThat(promptContent).contains("Java", "Spring Boot", "Database");
+        assertThat(promptContent).contains("jpa", "querydsl", "n+1");
     }
 }

--- a/backend/src/test/java/youngsu5582/tool/ai_tracker/support/IntegrationTestSupport.java
+++ b/backend/src/test/java/youngsu5582/tool/ai_tracker/support/IntegrationTestSupport.java
@@ -2,17 +2,25 @@ package youngsu5582.tool.ai_tracker.support;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.AfterEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.TestExecutionListeners.MergeMode;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
+import youngsu5582.tool.ai_tracker.application.service.AnalysisService;
 import youngsu5582.tool.ai_tracker.application.service.IngestionService;
+import youngsu5582.tool.ai_tracker.domain.category.CategoryRepository;
 import youngsu5582.tool.ai_tracker.domain.prompt.PromptRepository;
+import youngsu5582.tool.ai_tracker.domain.tag.TagRepository;
+import youngsu5582.tool.ai_tracker.provider.PromptAnalysisProvider;
 
 @TestExecutionListeners(
     listeners = EventCaptureListener.class,
@@ -34,11 +42,44 @@ public abstract class IntegrationTestSupport {
     protected PromptRepository promptRepository;
 
     @Autowired
+    protected CategoryRepository categoryRepository;
+
+    @Autowired
+    protected TagRepository tagRepository;
+
+    @Autowired
+    protected ApplicationEventPublisher eventPublisher;
+
+    @Autowired
     protected EventCaptureListener eventCaptureListener;
 
     @Autowired
     protected IngestionService ingestionService;
 
+    @MockitoBean
+    protected PromptAnalysisProvider promptAnalysisProvider;
+
+    @Autowired
+    protected AnalysisService analysisService;
+
     @PersistenceContext
     protected EntityManager entityManager;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    @AfterEach
+    void setup() {
+        // PostgreSQL의 BASE TABLE만 조회 (VIEW는 제외)
+        var tableNames = jdbcTemplate.queryForList(
+            "SELECT table_name FROM information_schema.tables " +
+                "WHERE table_schema = 'public' AND table_type = 'BASE TABLE'",
+            String.class
+        );
+
+        if (!tableNames.isEmpty()) {
+            // db 컨텍스트를 공유하는 테스트가 있어서 테스트 하기 전 로우들 청소
+            jdbcTemplate.execute("TRUNCATE TABLE " + String.join(", ", tableNames) + " CASCADE");
+        }
+    }
 }

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -1,8 +1,3 @@
-logging:
-  structured:
-    format:
-      console: ecs
-
 spring:
   jpa:
     hibernate:
@@ -12,6 +7,9 @@ spring:
       hibernate.jdbc.time_zone: UTC
 
     show-sql: true
+  ai:
+    openai:
+      api-key: sk-proj-test
 #  threads:
 #    virtual:
 #      enabled: true

--- a/backlog/tasks/task-008 - Phase-1.5-Prompt-Analysis-Service-구현-(TDD).md
+++ b/backlog/tasks/task-008 - Phase-1.5-Prompt-Analysis-Service-구현-(TDD).md
@@ -1,0 +1,36 @@
+---
+id: task-008
+title: 'Phase 1.5: Prompt Analysis Service 구현 (TDD)'
+status: In Progress
+assignee: []
+created_date: '2025-09-24 09:42'
+updated_date: '2025-10-18 14:26'
+labels:
+  - phase-1
+  - backend
+  - event
+  - async
+  - tdd
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+'PromptReceivedEvent'를 비동기적으로 수신하여 외부 AI API로 프롬프트를 분석하고, 분석 결과를 DB에 업데이트하는 'AnalysisService'를 구현합니다.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 '@EventListener'와 '@Async'를 사용하여 이벤트를 비동기적으로 처리하는 'AnalysisService' 메서드를 정의합니다. (메인 클래스에 @EnableAsync 추가)
+- [x] #2 메서드 전체를 '@Transactional'로 묶어 DB 업데이트의 원자성을 보장합니다.
+- [x] #3 외부 OpenAI API 호출을 시뮬레이션하는 'infrastructure/external/OpenAiClient.java' Mock 인터페이스를 생성합니다.
+- [x] #4 'AnalysisService' 통합 테스트에서 'ApplicationEventPublisher'로 이벤트를 직접 발행합니다.
+- [ ] #5 'Awaitility' 라이브러리를 사용하여 비동기 작업이 완료될 때까지 대기한 후, Prompt의 상태가 'COMPLETED'로 변경되었는지 검증합니다.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Spring의 비동기 처리(@Async)와 트랜잭션(@Transactional) 동작 방식을 학습합니다. 또한, 통합 테스트에서 외부 API 의존성을 '@MockBean'으로 제거하는 방법과 'Awaitility'를 이용한 비동기 테스트 방법을 익힙니다.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
### 📝 Related Task
- `task-008` 프롬프트 분석 서비스 구현

### 📄 Description
AI를 통해 프롬프트 내용을 분석하고, 그 결과를 `Prompt` 엔티티에 업데이트하여 저장하는 기능을 구현합니다. 
- `PromptAnalysisProvider` 인터페이스를 통해 분석 로직을 추상화하고, Spring AI를 이용한 `OpenAiPromptAnalysisProvider`와 테스트용 `FakePromptAnalysisProvider`를 구현했습니다.
- `PromptReceivedEvent`를 리스닝하여 비동기적으로 분석을 수행합니다.

### ✨ Key Changes
- **`PromptAnalysisProvider`**: 프롬프트 분석 책임을 분리하기 위한 인터페이스를 정의했습니다.
- **`FakePromptAnalysisProvider`**: API Key가 없는 환경(로컬, 테스트)을 위한 가짜 구현체를 추가했습니다. (`@ConditionalOnMissingBean`)
- **`OpenAiPromptAnalysisProvider`**: Spring AI의 `ChatClient`를 사용하여 실제 OpenAI API를 호출하는 구현체를 추가했습니다. (`@ConditionalOnProperty`)
- **`AnalysisService`**: `PromptReceivedEvent`를 받아 `PromptAnalysisProvider`를 통해 분석을 수행하고, 성공 또는 실패 결과를 `Prompt` 엔티티에 업데이트합니다.
- **`backlog`**: 관련 태스크(`task-008`) 문서를 추가했습니다.

### 🤖 To Reviewers
- Spring AI를 사용한 `OpenAiPromptAnalysisProvider`의 구현 방식이 적절한지 검토 부탁드립니다.
- 이벤트 기반으로 분석을 수행하는 `AnalysisService`의 비동기 처리 로직에 대한 의견 부탁드립니다.

### ✅ Checklist
- [x] PR 제목은 Conventional Commit Convention을 따랐습니다.
- [x] 관련 없는 코드를 포함하지 않았습니다.
- [x] 테스트 코드를 작성했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic prompt analysis using OpenAI for categorization and tagging.
  * Built-in fallback (fake) analysis when external AI is not available.
  * OpenAI integration configurable with retry and model settings.

* **Tests**
  * Expanded integration and unit tests covering analysis workflow and failure paths.
  * Improved test setup/teardown and test utilities for async event-driven scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->