### PR TITLE
feat: Phase 1.6 OpenSearch 연동 및 Prompt Document 색인 (Task 009)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -51,6 +51,7 @@ dependencies {
 
     // Database
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
     runtimeOnly 'org.postgresql:postgresql'
 
     // Lombok

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/application/service/AnalysisService.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/application/service/AnalysisService.java
@@ -17,6 +17,8 @@ import youngsu5582.tool.ai_tracker.domain.prompt.PromptRepository;
 import youngsu5582.tool.ai_tracker.domain.tag.Tag;
 import youngsu5582.tool.ai_tracker.domain.tag.TagRepository;
 import youngsu5582.tool.ai_tracker.domain.tag.Tags;
+import youngsu5582.tool.ai_tracker.infrastructure.persistence.document.PromptDocument;
+import youngsu5582.tool.ai_tracker.infrastructure.persistence.repository.PromptSearchRepository;
 import youngsu5582.tool.ai_tracker.provider.PromptAnalysisProvider;
 import youngsu5582.tool.ai_tracker.provider.dto.AnalysisMetadata;
 import youngsu5582.tool.ai_tracker.provider.dto.AnalysisMetadata.AnalysisMetadataAttribute;
@@ -34,6 +36,7 @@ public class AnalysisService {
     private final TagRepository tagRepository;
     private final CategoryRepository categoryRepository;
     private final PromptAnalysisProvider promptAnalysisProvider;
+    private final PromptSearchRepository promptSearchRepository;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -64,6 +67,7 @@ public class AnalysisService {
                 .stream().map(tag -> findOrSaveTag(tags, tag))
                 .toList();
             prompt.completeAnalyze(promptCategory, promptTags);
+            promptSearchRepository.save(PromptDocument.from(prompt));
 
             log.info("프롬프트 분석을 완료했습니다. ID: {}, 카테고리: {}, 태그 목록: {}", event.promptId(),
                 promptCategory, promptTags);

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/application/service/IngestionService.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/application/service/IngestionService.java
@@ -36,6 +36,7 @@ public class IngestionService {
                 .orElseGet(() -> promptRepository.save(Prompt.builder()
                         .status(PromptStatus.RECEIVED)
                         .messageId(captureRequest.getId())
+                        .createTime(captureRequest.getCreateTime())
                         .build()));
         prompt.updatePayload(captureRequest.getPayload());
         return prompt;

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/prompt/Prompt.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/prompt/Prompt.java
@@ -1,29 +1,7 @@
 package youngsu5582.tool.ai_tracker.domain.prompt;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.Table;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
@@ -32,6 +10,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import youngsu5582.tool.ai_tracker.common.entity.AuditEntity;
 import youngsu5582.tool.ai_tracker.domain.category.Category;
 import youngsu5582.tool.ai_tracker.domain.tag.Tag;
+
+import java.time.Instant;
+import java.util.*;
 
 @Entity
 @Table(name = "prompts")
@@ -77,6 +58,8 @@ public class Prompt extends AuditEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")
     private Category category;
+
+    private Instant createTime;
 
     public void assignCategory(Category category) {
         this.category = category;

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/infrastructure/persistence/document/PromptDocument.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/infrastructure/persistence/document/PromptDocument.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
@@ -13,6 +14,7 @@ import youngsu5582.tool.ai_tracker.domain.prompt.Prompt;
 import youngsu5582.tool.ai_tracker.domain.prompt.PromptTag;
 import youngsu5582.tool.ai_tracker.domain.tag.Tag;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -54,6 +56,12 @@ public class PromptDocument {
     @Field(type = FieldType.Keyword)
     private List<String> tags;
 
+    @Field(type = FieldType.Date, format = DateFormat.date_time)
+    private Instant createdAt;
+
+    @Field(type = FieldType.Date, format = DateFormat.date_time)
+    private Instant analyzedAt;
+
     public static PromptDocument from(Prompt prompt) {
         Objects.requireNonNull(prompt, "prompt must not be null");
 
@@ -61,26 +69,28 @@ public class PromptDocument {
         Category parentCategory = category != null ? category.getParentCategory() : null;
 
         List<String> tagNames = prompt.getPromptTags()
-            .stream()
-            .map(PromptTag::getTag)
-            .filter(Objects::nonNull)
-            .map(Tag::getName)
-            .filter(Objects::nonNull)
-            .distinct()
-            .sorted()
-            .collect(Collectors.toList());
+                .stream()
+                .map(PromptTag::getTag)
+                .filter(Objects::nonNull)
+                .map(Tag::getName)
+                .filter(Objects::nonNull)
+                .distinct()
+                .sorted()
+                .collect(Collectors.toList());
 
         return PromptDocument.builder()
-            .id(prompt.getUuid().toString())
-            .promptId(prompt.getId())
-            .messageId(prompt.getMessageId())
-            .provider(prompt.getProvider().getAlias())
-            .status(prompt.getStatus().name())
-            .payload(prompt.getPayload())
-            .error(prompt.getError())
-            .category(category != null ? category.getName() : null)
-            .parentCategory(parentCategory != null ? parentCategory.getName() : null)
-            .tags(tagNames)
-            .build();
+                .id(prompt.getUuid().toString())
+                .promptId(prompt.getId())
+                .messageId(prompt.getMessageId())
+                .provider(prompt.getProvider().getAlias())
+                .status(prompt.getStatus().name())
+                .payload(prompt.getPayload())
+                .error(prompt.getError())
+                .category(category != null ? category.getName() : null)
+                .parentCategory(parentCategory != null ? parentCategory.getName() : null)
+                .tags(tagNames)
+                .createdAt(prompt.getCreateTime())
+                .analyzedAt(Instant.now())
+                .build();
     }
 }

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/infrastructure/persistence/document/PromptDocument.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/infrastructure/persistence/document/PromptDocument.java
@@ -1,0 +1,86 @@
+package youngsu5582.tool.ai_tracker.infrastructure.persistence.document;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import youngsu5582.tool.ai_tracker.domain.category.Category;
+import youngsu5582.tool.ai_tracker.domain.prompt.Prompt;
+import youngsu5582.tool.ai_tracker.domain.prompt.PromptTag;
+import youngsu5582.tool.ai_tracker.domain.tag.Tag;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Document(indexName = "prompts")
+public class PromptDocument {
+
+    @Id
+    private String id;
+
+    @Field(type = FieldType.Long)
+    private Long promptId;
+
+    @Field(type = FieldType.Keyword)
+    private String messageId;
+
+    @Field(type = FieldType.Keyword)
+    private String provider;
+
+    @Field(type = FieldType.Keyword)
+    private String status;
+
+    @Field(type = FieldType.Text)
+    private String payload;
+
+    @Field(type = FieldType.Keyword)
+    private String error;
+
+    @Field(type = FieldType.Keyword)
+    private String category;
+
+    @Field(type = FieldType.Keyword)
+    private String parentCategory;
+
+    @Field(type = FieldType.Keyword)
+    private List<String> tags;
+
+    public static PromptDocument from(Prompt prompt) {
+        Objects.requireNonNull(prompt, "prompt must not be null");
+
+        Category category = prompt.getCategory();
+        Category parentCategory = category != null ? category.getParentCategory() : null;
+
+        List<String> tagNames = prompt.getPromptTags()
+            .stream()
+            .map(PromptTag::getTag)
+            .filter(Objects::nonNull)
+            .map(Tag::getName)
+            .filter(Objects::nonNull)
+            .distinct()
+            .sorted()
+            .collect(Collectors.toList());
+
+        return PromptDocument.builder()
+            .id(prompt.getUuid().toString())
+            .promptId(prompt.getId())
+            .messageId(prompt.getMessageId())
+            .provider(prompt.getProvider().getAlias())
+            .status(prompt.getStatus().name())
+            .payload(prompt.getPayload())
+            .error(prompt.getError())
+            .category(category != null ? category.getName() : null)
+            .parentCategory(parentCategory != null ? parentCategory.getName() : null)
+            .tags(tagNames)
+            .build();
+    }
+}

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/infrastructure/persistence/repository/PromptSearchRepository.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/infrastructure/persistence/repository/PromptSearchRepository.java
@@ -1,0 +1,8 @@
+package youngsu5582.tool.ai_tracker.infrastructure.persistence.repository;
+
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import youngsu5582.tool.ai_tracker.infrastructure.persistence.document.PromptDocument;
+
+public interface PromptSearchRepository extends ElasticsearchRepository<PromptDocument, String> {
+
+}

--- a/backend/src/test/java/youngsu5582/tool/ai_tracker/application/service/AnalysisServiceTests.java
+++ b/backend/src/test/java/youngsu5582/tool/ai_tracker/application/service/AnalysisServiceTests.java
@@ -3,6 +3,7 @@ package youngsu5582.tool.ai_tracker.application.service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import youngsu5582.tool.ai_tracker.MockEntityFactory;
 import youngsu5582.tool.ai_tracker.application.event.PromptReceivedEvent;
@@ -10,6 +11,7 @@ import youngsu5582.tool.ai_tracker.domain.category.Category;
 import youngsu5582.tool.ai_tracker.domain.prompt.Prompt;
 import youngsu5582.tool.ai_tracker.domain.prompt.PromptStatus;
 import youngsu5582.tool.ai_tracker.domain.tag.Tag;
+import youngsu5582.tool.ai_tracker.infrastructure.persistence.document.PromptDocument;
 import youngsu5582.tool.ai_tracker.provider.dto.AnalysisMetadata;
 import youngsu5582.tool.ai_tracker.provider.dto.AnalysisResult;
 import youngsu5582.tool.ai_tracker.support.IntegrationTestSupport;
@@ -57,6 +59,17 @@ class AnalysisServiceTests extends IntegrationTestSupport {
 
         assertThat(categoryRepository.findAll()).extracting(Category::getName)
                 .containsExactly("JPA");
+
+        ArgumentCaptor<PromptDocument> documentCaptor = ArgumentCaptor.forClass(PromptDocument.class);
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
+                Mockito.verify(promptSearchRepository).save(documentCaptor.capture())
+        );
+
+        PromptDocument document = documentCaptor.getValue();
+        assertThat(document.getId()).isEqualTo(prompt.getUuid().toString());
+        assertThat(document.getStatus()).isEqualTo(PromptStatus.COMPLETED.name());
+        assertThat(document.getCategory()).isEqualTo("JPA");
+        assertThat(document.getTags()).containsExactlyInAnyOrder("Java", "Spring");
     }
 
     @Test

--- a/backend/src/test/java/youngsu5582/tool/ai_tracker/support/IntegrationTestSupport.java
+++ b/backend/src/test/java/youngsu5582/tool/ai_tracker/support/IntegrationTestSupport.java
@@ -20,6 +20,7 @@ import youngsu5582.tool.ai_tracker.application.service.IngestionService;
 import youngsu5582.tool.ai_tracker.domain.category.CategoryRepository;
 import youngsu5582.tool.ai_tracker.domain.prompt.PromptRepository;
 import youngsu5582.tool.ai_tracker.domain.tag.TagRepository;
+import youngsu5582.tool.ai_tracker.infrastructure.persistence.repository.PromptSearchRepository;
 import youngsu5582.tool.ai_tracker.provider.PromptAnalysisProvider;
 
 @TestExecutionListeners(
@@ -58,6 +59,9 @@ public abstract class IntegrationTestSupport {
 
     @MockitoBean
     protected PromptAnalysisProvider promptAnalysisProvider;
+
+    @MockitoBean
+    protected PromptSearchRepository promptSearchRepository;
 
     @Autowired
     protected AnalysisService analysisService;

--- a/backlog/tasks/task-009 - Phase-1.6-OpenSearch-연동-및-Prompt-Document-색인-(TDD).md
+++ b/backlog/tasks/task-009 - Phase-1.6-OpenSearch-연동-및-Prompt-Document-색인-(TDD).md
@@ -1,0 +1,35 @@
+---
+id: task-009
+title: 'Phase 1.6: OpenSearch 연동 및 Prompt Document 색인 (TDD)'
+status: In Progress
+assignee: []
+created_date: '2025-09-24 09:42'
+updated_date: '2025-10-28 13:48'
+labels:
+  - phase-1
+  - backend
+  - opensearch
+  - search
+  - tdd
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+검색 및 분석을 위해 OpenSearch에 저장될 'PromptDocument' 모델을 정의하고, Spring Data Elasticsearch를 통해 분석된 프롬프트를 OpenSearch에 색인합니다.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 'infrastructure/persistence/document/PromptDocument.java'를 비정규화된 구조로 정의합니다. (@Document(indexName = "prompts"))
+- [x] #2 'infrastructure/persistence/repository/PromptSearchRepository.java' 인터페이스를 'ElasticsearchRepository'를 상속받아 생성합니다.
+- [x] #3 'AnalysisService' 로직에 분석 완료 후 'PromptDocument'를 생성하고 'promptSearchRepository.save()'를 호출하여 OpenSearch에 색인하는 코드를 추가합니다.
+- [x] #4 'AnalysisService' 통합 테스트에서, 비동기 작업 완료 후 'promptSearchRepository'를 통해 OpenSearch에 문서가 올바르게 색인되었는지 검증하는 로직을 추가합니다.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+RDB의 정규화된 모델과 검색엔진의 비정규화된 문서 모델의 차이점을 이해합니다. Spring Data Elasticsearch를 이용한 기본적인 OpenSearch 연동 및 데이터 색인 방법을 학습합니다.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## 📝 Related Task

- Closes #task-009

## 📄 Description

검색 및 분석을 위해 OpenSearch에 저장될 'PromptDocument' 모델을 정의하고, Spring Data Elasticsearch를 통해 분석된 프롬프트를 OpenSearch에 색인합니다.

이는 수집된 프롬프트 데이터의 검색 가능성을 확보하는 첫 단계이며, 사용자가 원하는 정보를 빠르게 찾을 수 있는 기반을 마련합니다.

## ✨ Key Changes

이번 PR의 주요 변경 사항은 다음과 같습니다.

- **`PromptDocument` 모델 정의**: OpenSearch에 색인될 비정규화된 데이터 구조인 `PromptDocument.java`를 `@Document(indexName = "prompts")` 어노테이션과 함께 생성했습니다.
- **`PromptSearchRepository` 인터페이스 생성**: Spring Data Elasticsearch의 `ElasticsearchRepository`를 상속받아 OpenSearch와의 데이터 상호작용을 위한 리포지토리를 구현했습니다.
- **`AnalysisService` 로직 수정**: 프롬프트 분석이 완료된 후, `PromptDocument`를 생성하고 `promptSearchRepository.save()`를 호출하여 OpenSearch에 데이터를 색인하는 로직을 추가했습니다.
- **통합 테스트 강화**: `AnalysisService`의 통합 테스트에서, 비동기 이벤트 처리가 완료된 후 `awaitility`를 사용하여 OpenSearch에 문서가 올바르게 색인되었는지 검증하는 로직을 추가하여 테스트의 신뢰성을 높였습니다.

## 🤖 To Reviewers

리뷰 시 아래 사항들을 중점적으로 확인해 주시면 감사하겠습니다.

- **OpenSearch/Elasticsearch 연동 확인**: `PromptDocument` 모델과 `PromptSearchRepository`의 설정, 그리고 `application.yml`의 OpenSearch 관련 설정이 올바른지 확인 부탁드립니다.
- **비동기 처리 및 테스트 검증**: `AnalysisService`의 비동기 로직(@Async)이 끝난 후, 테스트 코드에서 `awaitility`를 사용한 검증 방식이 안정적이고 효율적인지 검토 부탁드립니다.
- **데이터 비정규화 구조**: `PromptDocument`가 향후 검색 요구사항을 고려할 때, 검색에 최적화된 비정규화 구조를 잘 따르고 있는지 피드백 부탁드립니다.

## ✅ Checklist

- [x] 제 코드에 대한 자체 리뷰를 수행했습니다.
- [x] 이 프로젝트의 스타일 가이드라인을 따랐습니다.
- [x] 변경 사항에 대한 테스트 코드를 작성했습니다.
- [x] 모든 신규 및 기존 테스트를 통과했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Analyzed prompts are now indexed in a search engine for retrieval.
  * Prompt records now store a creation timestamp when captured.

* **Tests**
  * Added tests that verify prompt documents are persisted and indexed after analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->