### PR TITLE
feat: Phase 1.7 프롬프트 조회 API 구현 (Task 010)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     // Web
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     // Database
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -56,7 +57,6 @@ dependencies {
     }
     // OpenSearch Java 클라이언트 사용 시 권장 정렬 (starter가 3.2.0 이상을 기대)
     implementation 'org.opensearch.client:opensearch-java:3.3.0'
-    implementation 'org.opensearch.client:opensearch-rest-client:3.3.0' // 필요 시
 
     // ★ Spring Data 버전 충돌 해결 포인트
 //    implementation 'org.springframework.data:spring-data-elasticsearch:5.5.4'
@@ -77,7 +77,7 @@ dependencies {
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:postgresql'
 
-    testImplementation 'org.opensearch:opensearch-testcontainers:4.0.0'
+    testImplementation 'org.opensearch:opensearch-testcontainers:3.0.2'
 
     testImplementation 'org.awaitility:awaitility:4.2.1'
     testImplementation 'org.wiremock.integrations:wiremock-spring-boot:3.10.0'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -51,7 +51,17 @@ dependencies {
 
     // Database
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+    implementation('org.opensearch.client:spring-data-opensearch-starter:2.0.2') {
+        exclude group: 'org.opensearch.client', module: 'opensearch-rest-high-level-client'
+    }
+    // OpenSearch Java 클라이언트 사용 시 권장 정렬 (starter가 3.2.0 이상을 기대)
+    implementation 'org.opensearch.client:opensearch-java:3.3.0'
+    implementation 'org.opensearch.client:opensearch-rest-client:3.3.0' // 필요 시
+
+    // ★ Spring Data 버전 충돌 해결 포인트
+//    implementation 'org.springframework.data:spring-data-elasticsearch:5.5.4'
+//    implementation 'org.springframework.data:spring-data-commons:3.5.4'
+
     runtimeOnly 'org.postgresql:postgresql'
 
     // Lombok
@@ -66,6 +76,9 @@ dependencies {
     // For @ServiceConnection
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:postgresql'
+
+    testImplementation 'org.opensearch:opensearch-testcontainers:4.0.0'
+
     testImplementation 'org.awaitility:awaitility:4.2.1'
     testImplementation 'org.wiremock.integrations:wiremock-spring-boot:3.10.0'
 

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/AiTrackerApplication.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/AiTrackerApplication.java
@@ -2,8 +2,9 @@ package youngsu5582.tool.ai_tracker;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {ElasticsearchDataAutoConfiguration.class})
 public class AiTrackerApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/application/event/PromptAnalysisCompletedEvent.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/application/event/PromptAnalysisCompletedEvent.java
@@ -1,0 +1,4 @@
+package youngsu5582.tool.ai_tracker.application.event;
+
+public record PromptAnalysisCompletedEvent(long promptId) {
+}

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/application/service/AnalysisService.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/application/service/AnalysisService.java
@@ -51,9 +51,9 @@ public class AnalysisService {
             log.info("프롬프트 분석을 시작합니다. ID: {}", event.promptId());
 
             AnalysisMetadata metadata = new AnalysisMetadata(
-                Map.of(AnalysisMetadataAttribute.CATEGORY_LIST, categories.categoryNames(),
-                    AnalysisMetadataAttribute.TAG_LIST, tags.tagNames()
-                )
+                    Map.of(AnalysisMetadataAttribute.CATEGORY_LIST, categories.categoryNames(),
+                            AnalysisMetadataAttribute.TAG_LIST, tags.tagNames()
+                    )
             );
 
             // 프롬프트 분석한 결과
@@ -61,39 +61,45 @@ public class AnalysisService {
             log.info("분석한 응답: {}", result);
 
             // 데이터 설정
-            Category promptCategory = findOrSaveCategory(categories, result.category(),
-                result.parentCategory());
+            Category promptCategory = findOrSaveCategory(categories, result.category(), result.parentCategory());
             List<Tag> promptTags = result.tagList()
-                .stream().map(tag -> findOrSaveTag(tags, tag))
-                .toList();
+                    .stream().map(tag -> findOrSaveTag(tags, tag))
+                    .toList();
             prompt.completeAnalyze(promptCategory, promptTags);
-            promptSearchRepository.save(PromptDocument.from(prompt));
-
             log.info("프롬프트 분석을 완료했습니다. ID: {}, 카테고리: {}, 태그 목록: {}", event.promptId(),
-                promptCategory, promptTags);
+                    promptCategory, promptTags);
+
+            saveDocument(prompt);
         } catch (Exception e) {
             log.warn("프롬프트 분석을 실패했습니다! ID: {} 메시지: {}", event.promptId(), e.getMessage(), e);
             prompt.failAnalyze(e.getMessage());
         }
     }
 
+    private PromptDocument saveDocument(Prompt prompt) {
+        var promptDocument = promptSearchRepository.save(PromptDocument.from(prompt));
+        log.info("프롬프트 문서를 저장 했습니다. id: {}, result: {}", promptDocument.getId(), promptDocument);
+        return promptDocument;
+    }
+
+
     private Tag findOrSaveTag(Tags tags, String tagName) {
         return tags.findTag(tagName)
-            .orElseGet(() -> tagRepository.save(Tag.builder().name(tagName).build()));
+                .orElseGet(() -> tagRepository.save(Tag.builder().name(tagName).build()));
     }
 
     // 카테고리는 태그와 다소 다르다...
     // 왜냐하면, 부모 카테고리라는 개념이 존재 - AI 한테 묻고, 정보를 받아와야 함
     // 부모 개념이 존재하는거 같다면? -> AI 한테 받아오게
     private Category findOrSaveCategory(Categories categories,
-        String categoryName,
-        String parentCategoryName) {
+                                        String categoryName,
+                                        String parentCategoryName) {
         Category parentCategory = categories.findCategory(parentCategoryName).orElse(null);
         return categories.findCategory(categoryName)
-            .orElseGet(
-                () -> categoryRepository.save(Category.builder()
-                    .name(categoryName)
-                    .parentCategory(parentCategory)
-                    .build()));
+                .orElseGet(
+                        () -> categoryRepository.save(Category.builder()
+                                .name(categoryName)
+                                .parentCategory(parentCategory)
+                                .build()));
     }
 }

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/application/service/PromptDocumentService.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/application/service/PromptDocumentService.java
@@ -1,0 +1,34 @@
+package youngsu5582.tool.ai_tracker.application.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import youngsu5582.tool.ai_tracker.application.event.PromptAnalysisCompletedEvent;
+import youngsu5582.tool.ai_tracker.domain.prompt.PromptRepository;
+import youngsu5582.tool.ai_tracker.infrastructure.persistence.document.PromptDocument;
+import youngsu5582.tool.ai_tracker.infrastructure.persistence.repository.PromptSearchRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PromptDocumentService {
+
+    private final PromptSearchRepository promptSearchRepository;
+    private final PromptRepository promptRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Async
+    public void analysis(PromptAnalysisCompletedEvent event) {
+        long promptId = event.promptId();
+        log.info("프롬프트 문서화를 시작 합니다. id: {}", promptId);
+        var prompt = promptRepository.getByIdOrThrow(promptId);
+        var promptDocument = promptSearchRepository.save(PromptDocument.from(prompt));
+        log.info("프롬프트 문서를 저장 했습니다. id: {}, documentId: {}, result: {}", promptId, promptDocument.getId(), promptDocument);
+    }
+}

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/application/service/PromptQueryLogAppender.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/application/service/PromptQueryLogAppender.java
@@ -1,0 +1,22 @@
+package youngsu5582.tool.ai_tracker.application.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.opensearch.client.opensearch._types.OpenSearchException;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PromptQueryLogAppender {
+
+    public void appendErrorLog(OpenSearchException e) {
+        var err = e.error();
+        var root = err != null && !err.rootCause().isEmpty()
+                ? err.rootCause().getFirst() : null;
+        if (root != null) {
+            log.error("root_cause type={}, reason={}", root.type(), root.reason());
+        }
+        log.error("OS error status={}, type={}, reason={}", e.status(), (err != null ? err.type() : "n/a"), (err != null ? err.reason() : "n/a"), e);
+    }
+}

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/application/service/PromptQueryService.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/application/service/PromptQueryService.java
@@ -1,0 +1,224 @@
+package youngsu5582.tool.ai_tracker.application.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.stream.JsonGenerator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.json.PlainJsonSerializable;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.OpenSearchException;
+import org.opensearch.client.opensearch._types.SortOrder;
+import org.opensearch.client.opensearch._types.query_dsl.MatchAllQuery;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.Hit;
+import org.opensearch.client.opensearch.core.search.TotalHits;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import youngsu5582.tool.ai_tracker.application.service.dto.PromptSearchCommand;
+import youngsu5582.tool.ai_tracker.application.service.dto.PromptSearchResult;
+import youngsu5582.tool.ai_tracker.application.service.dto.PromptSearchResult.PromptSummary;
+import youngsu5582.tool.ai_tracker.infrastructure.persistence.document.PromptDocument;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class PromptQueryService {
+
+    private static final String CREATED_AT_FIELD = "createdAt";
+    private static final String PAYLOAD_FIELD = "payload";
+    private static final String TAGS_FIELD = "tags";
+    private static final String CATEGORY_FIELD = "category";
+    private static final String PARENT_CATEGORY_FIELD = "parentCategory";
+    private static final String INDEX_NAME = resolveIndexName();
+
+    private final OpenSearchClient openSearchClient;
+    private final PromptQueryLogAppender logAppender;
+    private final ObjectMapper objectMapper;
+
+    public PromptSearchResult getAll() {
+        var matchAll = MatchAllQuery.builder().build();
+        var query = Query.of(q -> q.matchAll(matchAll));
+        SearchRequest request = SearchRequest.of(sr -> sr
+                .query(query)
+                .index(INDEX_NAME)
+        );
+        try {
+            SearchResponse<PromptDocument> response = openSearchClient.search(request, PromptDocument.class);
+
+            List<PromptSummary> prompts = response.hits().hits().stream()
+                    .map(Hit::source)
+                    .filter(Objects::nonNull)
+                    .map(this::toSummary)
+                    .toList();
+
+            long total = extractTotalHits(response.hits().total(), prompts.size());
+            log.info("Prompt search completed. totalHits={}", total);
+            return new PromptSearchResult(total, prompts);
+
+        } catch (OpenSearchException e) {
+            logAppender.appendErrorLog(e);
+            throw new IllegalStateException("Failed to execute OpenSearch All query", e);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to execute OpenSearch query", e);
+        }
+    }
+
+    public PromptSearchResult search(PromptSearchCommand command) {
+        SearchRequest request = buildSearchRequest(command);
+        log.info("Executing prompt search. request={}", serializePlainJson(request));
+        if (request.query() != null) {
+            log.debug("Executing prompt search. query={}", serializePlainJson(request.query()));
+        }
+
+        try {
+            SearchResponse<PromptDocument> response = openSearchClient.search(request, PromptDocument.class);
+
+            List<PromptSummary> prompts = response.hits().hits().stream()
+                    .map(Hit::source)
+                    .filter(Objects::nonNull)
+                    .map(this::toSummary)
+                    .toList();
+
+            long total = extractTotalHits(response.hits().total(), prompts.size());
+            log.info("Prompt search completed. totalHits={}", total);
+            return new PromptSearchResult(total, prompts);
+        } catch (OpenSearchException e) {
+            logAppender.appendErrorLog(e);
+            throw new IllegalStateException("Failed to execute OpenSearch query: %s".formatted(command.searchText()), e);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to execute OpenSearch query", e);
+        }
+    }
+
+    private static long extractTotalHits(TotalHits totalHits, int fallback) {
+        return (totalHits == null) ? fallback : totalHits.value();
+    }
+
+    private SearchRequest buildSearchRequest(PromptSearchCommand command) {
+        // OR 그룹(should) + AND 그룹(filter[=기간])
+        List<Query> shouldQueries = new ArrayList<>();
+        List<Query> filterQueries = new ArrayList<>();
+
+        String searchText = command.searchText();
+
+        // term 으로 정확히 일치하는 요소들에 대해 검색 - OR
+        addShouldForKeyword(shouldQueries, TAGS_FIELD, searchText);
+        addShouldForKeyword(shouldQueries, CATEGORY_FIELD, searchText);
+        addShouldForKeyword(shouldQueries, PARENT_CATEGORY_FIELD, searchText);
+
+        // payload 는 match 로 검색 - OR
+        if (StringUtils.hasText(searchText)) {
+            shouldQueries.add(Query.of(q -> q.match(m -> m.field(PAYLOAD_FIELD).query(FieldValue.of(searchText)))));
+        }
+
+        // AND: 기간 필터
+        if (command.from() != null || command.to() != null) {
+            filterQueries.add(buildRangeFilter(command.from(), command.to()));
+        }
+
+        Query rootQuery = constructRootQuery(shouldQueries, filterQueries);
+
+        return SearchRequest.of(sr -> sr
+                .index(INDEX_NAME)
+                .query(rootQuery)
+                .sort(s -> s.field(f -> f.field(CREATED_AT_FIELD).order(SortOrder.Desc))));
+    }
+
+    /**
+     * should(OR) + minimum_should_match(1) + filter(AND) 조합
+     */
+    private static Query constructRootQuery(List<Query> shouldQueries, List<Query> filterQueries) {
+        return Query.of(q -> q.bool(b -> {
+            if (!shouldQueries.isEmpty()) {
+                b.should(shouldQueries).minimumShouldMatch("1");
+            }
+            if (!filterQueries.isEmpty()) {
+                b.filter(filterQueries);
+            }
+            return b;
+        }));
+    }
+
+    /**
+     * createdAt range: epoch_millis로 포맷 명시
+     */
+    private Query buildRangeFilter(Instant from, Instant to) {
+        return Query.of(q -> q.range(r -> {
+            r.field(CREATED_AT_FIELD);
+            r.format("epoch_millis");
+            if (from != null) {
+                r.gte(JsonData.of(from.toEpochMilli()));
+            }
+            if (to != null) {
+                r.lte(JsonData.of(to.toEpochMilli()));
+            }
+            return r;
+        }));
+    }
+
+    /**
+     * keyword(정확 일치)가 맞는 필드에 OR 조건 추가
+     */
+    private void addShouldForKeyword(List<Query> shoulds, String field, String value) {
+        if (StringUtils.hasText(value)) {
+            shoulds.add(Query.of(q -> q.term(t -> t.field(field).value(FieldValue.of(value)))));
+        }
+    }
+
+    private String serializePlainJson(PlainJsonSerializable serializable) {
+        if (serializable == null) {
+            return "";
+        }
+
+        try (ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
+            JacksonJsonpMapper mapper = new JacksonJsonpMapper(objectMapper);
+            try (JsonGenerator generator = mapper.jsonProvider().createGenerator(buffer)) {
+                serializable.serialize(generator, mapper);
+            }
+            return buffer.toString(StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            log.warn("Failed to serialize {} for logging. error={}", serializable.getClass().getSimpleName(), e.getMessage());
+            return "<serialization-error>";
+        }
+    }
+
+    private PromptSummary toSummary(PromptDocument document) {
+        List<String> tags = document.getTags() == null ? List.of() : document.getTags();
+        return new PromptSummary(
+                document.getId(),
+                document.getPromptId(),
+                document.getMessageId(),
+                document.getStatus(),
+                document.getProvider(),
+                document.getCategory(),
+                document.getParentCategory(),
+                tags,
+                document.getCreatedAt(),
+                document.getAnalyzedAt(),
+                document.getPayload(),
+                document.getError()
+        );
+    }
+
+    private static String resolveIndexName() {
+        Document annotation = PromptDocument.class.getAnnotation(Document.class);
+        if (annotation == null || !StringUtils.hasText(annotation.indexName())) {
+            throw new IllegalStateException("PromptDocument must declare an indexName");
+        }
+        return annotation.indexName();
+    }
+}

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/application/service/dto/PromptSearchCommand.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/application/service/dto/PromptSearchCommand.java
@@ -1,11 +1,31 @@
 package youngsu5582.tool.ai_tracker.application.service.dto;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 public record PromptSearchCommand(
         String searchText,
         Instant from,
         Instant to
 ) {
+
+    private static final int DEFAULT_SEARCH_DAYS = 14;
+
+
+    public PromptSearchCommand {
+        Instant effectiveTo = to == null ? Instant.now() : to;
+        Instant effectiveFrom = from == null
+                ? effectiveTo.minus(DEFAULT_SEARCH_DAYS, ChronoUnit.DAYS)
+                : from;
+
+        if (effectiveFrom.isAfter(effectiveTo)) {
+            throw new IllegalArgumentException(
+                    "'from(%s)' must not be after 'to(%s)'".formatted(effectiveFrom, effectiveTo)
+            );
+        }
+
+        from = effectiveFrom;
+        to = effectiveTo;
+    }
 
 }

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/application/service/dto/PromptSearchCommand.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/application/service/dto/PromptSearchCommand.java
@@ -1,0 +1,11 @@
+package youngsu5582.tool.ai_tracker.application.service.dto;
+
+import java.time.Instant;
+
+public record PromptSearchCommand(
+        String searchText,
+        Instant from,
+        Instant to
+) {
+
+}

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/application/service/dto/PromptSearchResult.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/application/service/dto/PromptSearchResult.java
@@ -1,0 +1,39 @@
+package youngsu5582.tool.ai_tracker.application.service.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
+
+import java.time.Instant;
+import java.util.List;
+
+public record PromptSearchResult(
+        long total,
+        List<PromptSummary> prompts
+) {
+
+    @JsonIgnore
+    public List<Long> getPromptIds() {
+        return prompts.stream().map(PromptSummary::id).toList();
+    }
+
+    public PromptSearchResult {
+        prompts = List.copyOf(prompts);
+    }
+
+    @Builder
+    public record PromptSummary(
+            String promptUuid,
+            Long id,
+            String messageId,
+            String status,
+            String provider,
+            String category,
+            String parentCategory,
+            List<String> tags,
+            Instant createdAt,
+            Instant analyzedAt,
+            String payload,
+            String error
+    ) {
+    }
+}

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/category/Category.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/category/Category.java
@@ -67,7 +67,7 @@ public class Category extends AuditEntity {
     @Override
     public String toString() {
         return "Category{" +
-            "id=" + id +
+            "promptUuid=" + id +
             ", uuid=" + uuid +
             ", name='" + name + '\'' +
             '}';

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/category/Category.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/category/Category.java
@@ -1,26 +1,14 @@
 package youngsu5582.tool.ai_tracker.domain.category;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import java.util.Objects;
-import java.util.UUID;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import youngsu5582.tool.ai_tracker.common.entity.AuditEntity;
+
+import java.util.Objects;
+import java.util.UUID;
 
 @Entity
 @Table(name = "categories")
@@ -67,7 +55,7 @@ public class Category extends AuditEntity {
     @Override
     public String toString() {
         return "Category{" +
-            "promptUuid=" + id +
+            "id=" + id +
             ", uuid=" + uuid +
             ", name='" + name + '\'' +
             '}';

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/prompt/Prompt.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/prompt/Prompt.java
@@ -59,11 +59,8 @@ public class Prompt extends AuditEntity {
     @JoinColumn(name = "category_id")
     private Category category;
 
-    private Instant createTime;
-
-    public void assignCategory(Category category) {
-        this.category = category;
-    }
+    @Builder.Default
+    private Instant createTime = Instant.now();
 
     public void failAnalyze(String error) {
         this.status = PromptStatus.FAILED;

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/prompt/Prompt.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/prompt/Prompt.java
@@ -55,7 +55,7 @@ public class Prompt extends AuditEntity {
     @Builder.Default
     private Set<PromptTag> promptTags = new HashSet<>();
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")
     private Category category;
 

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/tag/Tag.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/domain/tag/Tag.java
@@ -1,24 +1,16 @@
 package youngsu5582.tool.ai_tracker.domain.tag;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import java.util.Objects;
-import java.util.UUID;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import youngsu5582.tool.ai_tracker.common.entity.AuditEntity;
 
+import java.util.Objects;
+import java.util.UUID;
+
+@Data
 @Entity
 @Table(name = "tags")
 @Getter

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/infrastructure/persistence/document/PromptDocument.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/infrastructure/persistence/document/PromptDocument.java
@@ -1,11 +1,11 @@
 package youngsu5582.tool.ai_tracker.infrastructure.persistence.document;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.elasticsearch.annotations.DateFormat;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 @AllArgsConstructor
 @Document(indexName = "prompts")
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PromptDocument {
 
     @Id
@@ -35,16 +36,16 @@ public class PromptDocument {
     @Field(type = FieldType.Keyword)
     private String messageId;
 
-    @Field(type = FieldType.Keyword)
+    @Field(type = FieldType.Keyword, index = false)
     private String provider;
 
-    @Field(type = FieldType.Keyword)
+    @Field(type = FieldType.Keyword, index = false)
     private String status;
 
     @Field(type = FieldType.Text)
     private String payload;
 
-    @Field(type = FieldType.Keyword)
+    @Field(type = FieldType.Keyword, index = false)
     private String error;
 
     @Field(type = FieldType.Keyword)
@@ -56,10 +57,10 @@ public class PromptDocument {
     @Field(type = FieldType.Keyword)
     private List<String> tags;
 
-    @Field(type = FieldType.Date, format = DateFormat.date_time)
+    @Field(type = FieldType.Date)
     private Instant createdAt;
 
-    @Field(type = FieldType.Date, format = DateFormat.date_time)
+    @Field(type = FieldType.Date)
     private Instant analyzedAt;
 
     public static PromptDocument from(Prompt prompt) {

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/presentation/api/PromptQueryController.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/presentation/api/PromptQueryController.java
@@ -1,0 +1,39 @@
+package youngsu5582.tool.ai_tracker.presentation.api;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import youngsu5582.tool.ai_tracker.application.service.PromptQueryService;
+import youngsu5582.tool.ai_tracker.application.service.dto.PromptSearchResult;
+import youngsu5582.tool.ai_tracker.presentation.api.dto.PromptSearchRequest;
+import youngsu5582.tool.ai_tracker.presentation.api.dto.PromptSearchResponse;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(path = "/api/v1/prompts", produces = APPLICATION_JSON_VALUE)
+public class PromptQueryController {
+
+    private final PromptQueryService promptQueryService;
+
+    @GetMapping("/search")
+    public PromptSearchResponse search(@Valid PromptSearchRequest request) {
+        log.info("search request: {}", request);
+        PromptSearchResult result = promptQueryService.search(request.toCommand());
+        log.info("search result: {}", result.getPromptIds());
+        return PromptSearchResponse.from(result);
+    }
+
+    @GetMapping("/all")
+    public PromptSearchResponse searchAll() {
+        log.info("searchAll request");
+        PromptSearchResult result = promptQueryService.getAll();
+        log.info("searchAll result: {}", result.getPromptIds());
+        return PromptSearchResponse.from(result);
+    }
+}

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/presentation/api/dto/CaptureRequest.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/presentation/api/dto/CaptureRequest.java
@@ -35,7 +35,7 @@ public class CaptureRequest {
     private String conversationId;
 
     /**
-     * 현재 노드 id
+     * 현재 노드 promptUuid
      */
     @NotNull
     private String id;
@@ -81,7 +81,7 @@ public class CaptureRequest {
     private Integer weight;
 
     /**
-     * 상위 메시지 id
+     * 상위 메시지 promptUuid
      */
     private String parent;
 

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/presentation/api/dto/PromptSearchRequest.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/presentation/api/dto/PromptSearchRequest.java
@@ -1,0 +1,22 @@
+package youngsu5582.tool.ai_tracker.presentation.api.dto;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
+import youngsu5582.tool.ai_tracker.application.service.dto.PromptSearchCommand;
+
+import java.time.Instant;
+
+public record PromptSearchRequest(
+        String searchText,
+        @DateTimeFormat(iso = ISO.DATE_TIME) Instant from,
+        @DateTimeFormat(iso = ISO.DATE_TIME) Instant to
+) {
+
+    public PromptSearchCommand toCommand() {
+        return new PromptSearchCommand(
+                searchText,
+                from,
+                to
+        );
+    }
+}

--- a/backend/src/main/java/youngsu5582/tool/ai_tracker/presentation/api/dto/PromptSearchResponse.java
+++ b/backend/src/main/java/youngsu5582/tool/ai_tracker/presentation/api/dto/PromptSearchResponse.java
@@ -1,0 +1,55 @@
+package youngsu5582.tool.ai_tracker.presentation.api.dto;
+
+import youngsu5582.tool.ai_tracker.application.service.dto.PromptSearchResult;
+import youngsu5582.tool.ai_tracker.application.service.dto.PromptSearchResult.PromptSummary;
+
+import java.time.Instant;
+import java.util.List;
+
+public record PromptSearchResponse(
+    long total,
+    List<PromptSummaryResponse> prompts
+) {
+
+    public static PromptSearchResponse from(PromptSearchResult result) {
+        return new PromptSearchResponse(
+            result.total(),
+            result.prompts().stream()
+                .map(PromptSummaryResponse::from)
+                .toList()
+        );
+    }
+
+    public record PromptSummaryResponse(
+        String id,
+        Long promptId,
+        String messageId,
+        String status,
+        String provider,
+        String category,
+        String parentCategory,
+        List<String> tags,
+        Instant createdAt,
+        Instant analyzedAt,
+        String payload,
+        String error
+    ) {
+
+        public static PromptSummaryResponse from(PromptSummary summary) {
+            return new PromptSummaryResponse(
+                summary.promptUuid(),
+                summary.id(),
+                summary.messageId(),
+                summary.status(),
+                summary.provider(),
+                summary.category(),
+                summary.parentCategory(),
+                summary.tags(),
+                summary.createdAt(),
+                summary.analyzedAt(),
+                summary.payload(),
+                summary.error()
+            );
+        }
+    }
+}

--- a/backend/src/test/java/youngsu5582/tool/ai_tracker/MockEntityFactory.java
+++ b/backend/src/test/java/youngsu5582/tool/ai_tracker/MockEntityFactory.java
@@ -2,13 +2,14 @@ package youngsu5582.tool.ai_tracker;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.navercorp.fixturemonkey.FixtureMonkey;
-import java.util.Collections;
-import java.util.UUID;
 import youngsu5582.tool.ai_tracker.domain.category.Category;
 import youngsu5582.tool.ai_tracker.domain.prompt.Prompt;
 import youngsu5582.tool.ai_tracker.domain.prompt.PromptStatus;
 import youngsu5582.tool.ai_tracker.domain.tag.Tag;
 import youngsu5582.tool.ai_tracker.presentation.api.dto.CaptureRequest;
+
+import java.util.Collections;
+import java.util.UUID;
 
 public class MockEntityFactory {
 
@@ -17,28 +18,28 @@ public class MockEntityFactory {
 
     public static Prompt createPrompt(PromptStatus promptStatus) {
         return Prompt.builder()
-            .status(promptStatus)
-            .payload(handleException(() -> objectMapper.writeValueAsString("value")))
-            .build();
+                .status(promptStatus)
+                .payload(handleException(() -> objectMapper.writeValueAsString("value")))
+                .build();
     }
 
     public static Tag createTag(String name) {
         return Tag.builder()
-            .name(name)
-            .build();
+                .name(name)
+                .build();
     }
 
     public static Category createCategory(String name) {
         return Category.builder()
-            .name(name)
-            .build();
+                .name(name)
+                .build();
     }
 
     public static Category createCategory(String name, Category parent) {
         return Category.builder()
-            .name(name)
-            .parentCategory(parent)
-            .build();
+                .name(name)
+                .parentCategory(parent)
+                .build();
     }
 
     private static <T> T handleException(ThrowableSupplier<T> supplier) {
@@ -51,13 +52,13 @@ public class MockEntityFactory {
 
     public static CaptureRequest getCaptureRequest() {
         return FIXTURE_MONKEY.giveMeBuilder(CaptureRequest.class)
-            .setNotNull("id")
-            .setNotNull("message")
-            .setNotNull("message.content")
-            .minSize("message.content.parts", 1)
-            .set("message.author.metadata", Collections.emptyMap())
-            .set("id", UUID.randomUUID().toString())
-            .sample();
+                .setNotNull("id")
+                .setNotNull("message")
+                .setNotNull("message.content")
+                .minSize("message.content.parts", 1)
+                .set("message.author.metadata", Collections.emptyMap())
+                .set("id", UUID.randomUUID().toString())
+                .sample();
     }
 
     @FunctionalInterface

--- a/backend/src/test/java/youngsu5582/tool/ai_tracker/application/service/AnalysisServiceTests.java
+++ b/backend/src/test/java/youngsu5582/tool/ai_tracker/application/service/AnalysisServiceTests.java
@@ -10,6 +10,7 @@ import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import youngsu5582.tool.ai_tracker.MockEntityFactory;
+import youngsu5582.tool.ai_tracker.application.event.PromptAnalysisCompletedEvent;
 import youngsu5582.tool.ai_tracker.application.event.PromptReceivedEvent;
 import youngsu5582.tool.ai_tracker.domain.category.Category;
 import youngsu5582.tool.ai_tracker.domain.prompt.Prompt;
@@ -68,6 +69,9 @@ class AnalysisServiceTests extends IntegrationTestSupport {
         SearchRequest searchRequest = SearchRequest.of(search -> search.query(
                 Query.of(query -> query.match(MatchQuery.of(match -> match.field("category").query(FieldValue.of("JPA")))))
         ));
+
+        var event = eventCaptureListener.findEventsOfType(PromptAnalysisCompletedEvent.class);
+        assertThat(event).isNotNull().contains(new PromptAnalysisCompletedEvent(prompt.getId()));
         SearchResponse<PromptDocument> search = openSearchClient.search(searchRequest, PromptDocument.class);
         assertThat(search.hits().hits()).hasSize(1);
     }

--- a/backend/src/test/java/youngsu5582/tool/ai_tracker/application/service/AnalysisServiceTests.java
+++ b/backend/src/test/java/youngsu5582/tool/ai_tracker/application/service/AnalysisServiceTests.java
@@ -3,8 +3,12 @@ package youngsu5582.tool.ai_tracker.application.service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.query_dsl.MatchQuery;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
 import youngsu5582.tool.ai_tracker.MockEntityFactory;
 import youngsu5582.tool.ai_tracker.application.event.PromptReceivedEvent;
 import youngsu5582.tool.ai_tracker.domain.category.Category;
@@ -16,6 +20,7 @@ import youngsu5582.tool.ai_tracker.provider.dto.AnalysisMetadata;
 import youngsu5582.tool.ai_tracker.provider.dto.AnalysisResult;
 import youngsu5582.tool.ai_tracker.support.IntegrationTestSupport;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 
@@ -35,13 +40,13 @@ class AnalysisServiceTests extends IntegrationTestSupport {
 
     @Test
     @DisplayName("분석 제공자를 통해 프롬프트를 분석해 저장한다.")
-    void analyzeCompleteAndChangeComplete() {
+    void analyzeCompleteAndChangeComplete() throws IOException {
         // given
         Mockito.doReturn(AnalysisResult.builder()
                         .category("JPA")
                         .tagList(List.of("Java", "Spring"))
-                        .build()).when(promptAnalysisProvider)
-                .analyze(anyString(), any(AnalysisMetadata.class));
+                        .build())
+                .when(promptAnalysisProvider).analyze(anyString(), any(AnalysisMetadata.class));
 
         // when
         eventPublisher.publishEvent(new PromptReceivedEvent(prompt.getId()));
@@ -60,16 +65,11 @@ class AnalysisServiceTests extends IntegrationTestSupport {
         assertThat(categoryRepository.findAll()).extracting(Category::getName)
                 .containsExactly("JPA");
 
-        ArgumentCaptor<PromptDocument> documentCaptor = ArgumentCaptor.forClass(PromptDocument.class);
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
-                Mockito.verify(promptSearchRepository).save(documentCaptor.capture())
-        );
-
-        PromptDocument document = documentCaptor.getValue();
-        assertThat(document.getId()).isEqualTo(prompt.getUuid().toString());
-        assertThat(document.getStatus()).isEqualTo(PromptStatus.COMPLETED.name());
-        assertThat(document.getCategory()).isEqualTo("JPA");
-        assertThat(document.getTags()).containsExactlyInAnyOrder("Java", "Spring");
+        SearchRequest searchRequest = SearchRequest.of(search -> search.query(
+                Query.of(query -> query.match(MatchQuery.of(match -> match.field("category").query(FieldValue.of("JPA")))))
+        ));
+        SearchResponse<PromptDocument> search = openSearchClient.search(searchRequest, PromptDocument.class);
+        assertThat(search.hits().hits()).hasSize(1);
     }
 
     @Test

--- a/backend/src/test/java/youngsu5582/tool/ai_tracker/application/service/PromptQueryServiceOpenSearchIntegrationTests.java
+++ b/backend/src/test/java/youngsu5582/tool/ai_tracker/application/service/PromptQueryServiceOpenSearchIntegrationTests.java
@@ -1,0 +1,135 @@
+package youngsu5582.tool.ai_tracker.application.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.elasticsearch.core.IndexOperations;
+import youngsu5582.tool.ai_tracker.application.service.dto.PromptSearchCommand;
+import youngsu5582.tool.ai_tracker.application.service.dto.PromptSearchResult;
+import youngsu5582.tool.ai_tracker.infrastructure.persistence.document.PromptDocument;
+import youngsu5582.tool.ai_tracker.support.IntegrationTestSupport;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PromptQueryServiceOpenSearchIntegrationTests extends IntegrationTestSupport {
+
+    @Autowired
+    PromptQueryTestingService promptQueryTestingService;
+
+    @BeforeEach
+    void setup() {
+        initData();
+    }
+
+    @AfterEach
+    void tearDown() {
+        deleteData();
+    }
+
+    @Test
+    @DisplayName("OpenSearch에 저장된 문서를 키워드와 태그, 카테고리 조건으로 필터링한다.")
+    void search_withKeywordAndTags_filtersDocuments() {
+        PromptSearchCommand command = new PromptSearchCommand(
+                "latency",
+                Instant.parse("2024-04-01T00:00:00Z"),
+                Instant.parse("2024-06-01T00:00:00Z"));
+        // when & then
+
+        PromptSearchResult result = promptQueryService.search(command);
+        assertThat(result.total()).isEqualTo(3L);
+        assertThat(result.prompts()).hasSize(3);
+        assertThat(result.prompts()).extracting(PromptSearchResult.PromptSummary::messageId)
+                .contains("message-1", "message-2", "message-3");
+    }
+
+    @Test
+    @DisplayName("모든 요소를 검색한다")
+    void search_all() {
+        List<PromptDocument> promptDocumentList = promptQueryTestingService.searchAll();
+        assertThat(promptDocumentList).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("카테고리로 검색한다")
+    void search_category() {
+        List<PromptDocument> promptDocumentList = promptQueryTestingService.searchByCategory("Generative AI");
+        assertThat(promptDocumentList).hasSize(1)
+                .extracting(PromptDocument::getId)
+                .contains("uuid-1");
+    }
+
+    @Test
+    @DisplayName("태그로 검색한다")
+    void search_tag() {
+        List<PromptDocument> promptDocumentList = promptQueryTestingService.searchWithTag("otel");
+        assertThat(promptDocumentList).hasSize(1)
+                .extracting(PromptDocument::getId)
+                .contains("uuid-3");
+    }
+
+    @Test
+    @DisplayName("페이로드로 검색한다")
+    void search_payload() {
+        List<PromptDocument> promptDocumentList = promptQueryTestingService.searchWithPayload("for");
+        assertThat(promptDocumentList).hasSize(2)
+                .extracting(PromptDocument::getId)
+                .contains("uuid-2", "uuid-3");
+    }
+
+    private void initData() {
+        // given
+        promptSearchRepository.saveAll(
+                List.of(
+                        PromptDocument.builder()
+                                .id("uuid-1")
+                                .promptId(1L)
+                                .messageId("message-1")
+                                .provider("OPENAI")
+                                .status("COMPLETED")
+                                .payload("Investigate latency patterns with java prompt-engineering techniques.")
+                                .category("Generative AI")
+                                .parentCategory("Architecture")
+                                .tags(List.of("java", "prompt-engineering"))
+                                .createdAt(Instant.parse("2024-05-01T10:00:00Z"))
+                                .analyzedAt(Instant.parse("2024-05-01T11:00:00Z"))
+                                .build(),
+                        PromptDocument.builder()
+                                .id("uuid-2")
+                                .promptId(2L)
+                                .messageId("message-2")
+                                .provider("OPENAI")
+                                .status("FAILED")
+                                .payload("Explore caching for throughput optimisation.")
+                                .category("latency")
+                                .tags(List.of("spring", "performance"))
+                                .createdAt(Instant.parse("2024-05-01T12:00:00Z"))
+                                .analyzedAt(Instant.parse("2024-05-01T13:00:00Z"))
+                                .build(),
+                        PromptDocument.builder()
+                                .id("uuid-3")
+                                .promptId(3L)
+                                .messageId("message-3")
+                                .provider("ANTHROPIC")
+                                .status("COMPLETED")
+                                .payload("analysis for distributed tracing pipelines.")
+                                .category("Observability")
+                                .tags(List.of("otel", "latency"))
+                                .createdAt(Instant.parse("2024-05-02T09:00:00Z"))
+                                .analyzedAt(Instant.parse("2024-05-02T09:30:00Z"))
+                                .build()
+                ));
+
+
+        IndexOperations indexOps = openSearchOperations.indexOps(PromptDocument.class);
+        indexOps.refresh();
+    }
+
+    private void deleteData() {
+        promptQueryTestingService.deleteAllDocuments();
+    }
+}

--- a/backend/src/test/java/youngsu5582/tool/ai_tracker/application/service/PromptQueryTestingService.java
+++ b/backend/src/test/java/youngsu5582/tool/ai_tracker/application/service/PromptQueryTestingService.java
@@ -1,0 +1,86 @@
+package youngsu5582.tool.ai_tracker.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.query_dsl.MatchAllQuery;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch.core.DeleteByQueryRequest;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.Hit;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.util.StringUtils;
+import youngsu5582.tool.ai_tracker.infrastructure.persistence.document.PromptDocument;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@TestComponent
+@RequiredArgsConstructor
+public class PromptQueryTestingService {
+
+    private final OpenSearchClient openSearchClient;
+
+    private static final String INDEX_NAME = resolveIndexName();
+
+    public List<PromptDocument> searchWithTag(String tag) {
+        final Query matchQuery = Query.of(q -> q.match(
+                m -> m.field("tags").query(FieldValue.of(tag))));
+        return executeSearch(matchQuery);
+    }
+
+    public List<PromptDocument> searchWithPayload(String payload) {
+        final Query matchQuery = Query.of(q -> q.match(m -> m.field("payload").query(FieldValue.of(payload))));
+        return executeSearch(matchQuery);
+    }
+
+
+    public List<PromptDocument> searchAll() {
+        final Query matchQuery = Query.of(q -> q.matchAll(MatchAllQuery.builder().build()));
+        return executeSearch(matchQuery);
+    }
+
+    public List<PromptDocument> searchByCategory(String category) {
+        final Query matchQuery = Query.of(q -> q.match(m -> m.field("category").query(FieldValue.of(category))));
+        return executeSearch(matchQuery);
+    }
+
+    private List<PromptDocument> executeSearch(final Query query) {
+        final SearchRequest.Builder builder = new SearchRequest.Builder()
+                .index(INDEX_NAME)
+                .query(query);
+
+        try {
+            final SearchResponse<PromptDocument> response = openSearchClient.search(builder.build(), PromptDocument.class);
+            return response.hits().hits().stream()
+                    .map(Hit::source)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+        } catch (final IOException ioException) {
+            throw new UncheckedIOException("Search failed for index %s".formatted(INDEX_NAME), ioException);
+        }
+    }
+
+    public void deleteAllDocuments() {
+        try {
+            openSearchClient.deleteByQuery(
+                    DeleteByQueryRequest.of(builder -> builder.index(INDEX_NAME)
+                            .query(q -> q.matchAll(m -> m))));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to delete documents for index %s".formatted(INDEX_NAME), e);
+        }
+    }
+
+    private static String resolveIndexName() {
+        Document annotation = PromptDocument.class.getAnnotation(Document.class);
+        if (annotation == null || !StringUtils.hasText(annotation.indexName())) {
+            throw new IllegalStateException("PromptDocument must declare an indexName");
+        }
+        return annotation.indexName();
+    }
+}

--- a/backend/src/test/java/youngsu5582/tool/ai_tracker/presentation/api/PromptQueryControllerTests.java
+++ b/backend/src/test/java/youngsu5582/tool/ai_tracker/presentation/api/PromptQueryControllerTests.java
@@ -12,6 +12,8 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class PromptQueryControllerTests extends ControllerTestSupport {
@@ -30,6 +32,28 @@ class PromptQueryControllerTests extends ControllerTestSupport {
                         .accept(MediaType.APPLICATION_JSON));
 
         // then
+        assertThat(response).hasStatus2xxSuccessful();
+    }
+
+    @Test
+    @DisplayName("검색 API는 질의 조건을 서비스로 전달하고 검색 결과를 반환한다.")
+    void search_prompts_withQueryParameters_from_to() {
+        // given
+
+        PromptSearchResult result = getPromptSummaryList();
+        when(promptQueryService.search(any())).thenReturn(result);
+
+        // when
+        var response = mvc.perform(
+                MockMvcRequestBuilders.get("/api/v1/prompts/search?searchText=latency&from=2024-01-01T00:00:00Z&to=2024-12-31T23:59:59Z")
+                        .accept(MediaType.APPLICATION_JSON));
+
+        // then
+        verify(promptQueryService).search(argThat(cmd ->
+                "latency".equals(cmd.searchText()) &&
+                        Instant.parse("2024-01-01T00:00:00Z").equals(cmd.from()) &&
+                        Instant.parse("2024-12-31T23:59:59Z").equals(cmd.to())
+        ));
         assertThat(response).hasStatus2xxSuccessful();
     }
 

--- a/backend/src/test/java/youngsu5582/tool/ai_tracker/presentation/api/PromptQueryControllerTests.java
+++ b/backend/src/test/java/youngsu5582/tool/ai_tracker/presentation/api/PromptQueryControllerTests.java
@@ -1,0 +1,72 @@
+package youngsu5582.tool.ai_tracker.presentation.api;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import youngsu5582.tool.ai_tracker.application.service.dto.PromptSearchResult;
+import youngsu5582.tool.ai_tracker.support.ControllerTestSupport;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class PromptQueryControllerTests extends ControllerTestSupport {
+
+    @Test
+    @DisplayName("검색 API는 질의 조건을 서비스로 전달하고 검색 결과를 반환한다.")
+    void search_prompts_withQueryParameters() {
+        // given
+
+        PromptSearchResult result = getPromptSummaryList();
+        when(promptQueryService.search(any())).thenReturn(result);
+
+        // when
+        var response = mvc.perform(
+                MockMvcRequestBuilders.get("/api/v1/prompts/search?searchText=latency")
+                        .accept(MediaType.APPLICATION_JSON));
+
+        // then
+        assertThat(response).hasStatus2xxSuccessful();
+    }
+
+    @Test
+    @DisplayName("모든 결과를 반환한다.")
+    void get_all_prompts() {
+        // given
+
+        PromptSearchResult result = getPromptSummaryList();
+        when(promptQueryService.getAll()).thenReturn(result);
+
+        // when
+        var response = mvc.perform(
+                MockMvcRequestBuilders.get("/api/v1/prompts/all")
+                        .accept(MediaType.APPLICATION_JSON));
+
+        // then
+        assertThat(response).hasStatus2xxSuccessful();
+    }
+
+    private PromptSearchResult getPromptSummaryList() {
+        return new PromptSearchResult(
+                1L,
+                List.of(new PromptSearchResult.PromptSummary(
+                        "uuid-1",
+                        42L,
+                        "message-123",
+                        "COMPLETED",
+                        "OPENAI",
+                        "Generative AI",
+                        "Architecture",
+                        List.of("java", "prompt-engineering"),
+                        Instant.parse("2024-05-01T10:00:00Z"),
+                        Instant.parse("2024-05-01T11:00:00Z"),
+                        "Investigate latency patterns with java prompt-engineering techniques.",
+                        null
+                ))
+        );
+    }
+}

--- a/backend/src/test/java/youngsu5582/tool/ai_tracker/support/ControllerTestSupport.java
+++ b/backend/src/test/java/youngsu5582/tool/ai_tracker/support/ControllerTestSupport.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 import youngsu5582.tool.ai_tracker.application.service.IngestionService;
+import youngsu5582.tool.ai_tracker.application.service.PromptQueryService;
 
 @AutoConfigureMockMvc
 @WebMvcTest
@@ -21,4 +22,7 @@ public abstract class ControllerTestSupport {
 
     @MockitoBean
     protected IngestionService ingestionService;
+
+    @MockitoBean
+    protected PromptQueryService promptQueryService;
 }

--- a/backend/src/test/java/youngsu5582/tool/ai_tracker/support/IntegrationTestSupport.java
+++ b/backend/src/test/java/youngsu5582/tool/ai_tracker/support/IntegrationTestSupport.java
@@ -3,44 +3,103 @@ package youngsu5582.tool.ai_tracker.support;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.data.core.OpenSearchOperations;
+import org.opensearch.testcontainers.OpenSearchContainer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.TestExecutionListeners.MergeMode;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.util.StringUtils;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import youngsu5582.tool.ai_tracker.application.service.AnalysisService;
 import youngsu5582.tool.ai_tracker.application.service.IngestionService;
+import youngsu5582.tool.ai_tracker.application.service.PromptQueryService;
+import youngsu5582.tool.ai_tracker.application.service.PromptQueryTestingService;
 import youngsu5582.tool.ai_tracker.domain.category.CategoryRepository;
 import youngsu5582.tool.ai_tracker.domain.prompt.PromptRepository;
 import youngsu5582.tool.ai_tracker.domain.tag.TagRepository;
+import youngsu5582.tool.ai_tracker.infrastructure.persistence.document.PromptDocument;
 import youngsu5582.tool.ai_tracker.infrastructure.persistence.repository.PromptSearchRepository;
 import youngsu5582.tool.ai_tracker.provider.PromptAnalysisProvider;
 
+import java.util.Map;
+
 @TestExecutionListeners(
-    listeners = EventCaptureListener.class,
-    mergeMode = MergeMode.MERGE_WITH_DEFAULTS
+        listeners = EventCaptureListener.class,
+        mergeMode = MergeMode.MERGE_WITH_DEFAULTS
 )
 @ActiveProfiles("test")
-@Import(EventCaptureListener.class)
+@Testcontainers
+@Import({EventCaptureListener.class, PromptQueryTestingService.class})
 @SpringBootTest
 public abstract class IntegrationTestSupport {
 
     private static final String POSTGRES_IMAGE_NAME = "postgres:16.1";
+    private static final String OPENSEARCH_IMAGE_NAME = "opensearchproject/opensearch:3.1.0";
+    private static final String PROMPT_INDEX_NAME = resolveIndexName();
 
     @ServiceConnection
-    static PostgreSQLContainer<?> postgresqlContainer = new PostgreSQLContainer<>(
-        POSTGRES_IMAGE_NAME)
-        .waitingFor(Wait.forListeningPort());
+    static PostgreSQLContainer<?> postgresqlContainer = new PostgreSQLContainer<>(POSTGRES_IMAGE_NAME)
+            .waitingFor(Wait.forListeningPort());
+
+    // OpenSearch 는 아직 ServiceConnection 제공 하지 않음
+    // @ServiceConnection
+    // No ConnectionDetails found for source '@ServiceConnection source for IntegrationTestSupport.opensearch'
+    static final OpenSearchContainer<?> OPENSEARCH_CONTAINER = new OpenSearchContainer<>(
+            OPENSEARCH_IMAGE_NAME).withEnv("DISABLE_SECURITY_PLUGIN", "true");
+
+    static {
+        OPENSEARCH_CONTAINER.start();
+    }
+
+    @DynamicPropertySource
+    static void opensearchProps(DynamicPropertyRegistry r) {
+        // spring-data-opensearch-starter 는 spring.opensearch.* 프리픽스를 사용
+        r.add("spring.opensearch.uris", () -> "http://" + OPENSEARCH_CONTAINER.getHttpHostAddress());
+        // 필요시 타임아웃 등
+        // r.add("spring.opensearch.connection-timeout", () -> "3s");
+        // r.add("spring.opensearch.socket-timeout", () -> "30s");
+    }
+
+    @BeforeEach
+    void ensureIndex() {
+        var ops = openSearchOperations.indexOps(PromptDocument.class);
+
+        if (!ops.exists()) {
+            // ① 설정
+            Map<String, Object> settings = Map.of(
+                    "index.number_of_shards", 1,
+                    "index.number_of_replicas", 0
+            );
+
+            // ② 매핑
+            var mapping = ops.createMapping(PromptDocument.class);
+
+            // ③ 설정+매핑으로 인덱스 생성
+            ops.create(settings, mapping);
+        }
+
+        ops.refresh();
+    }
 
     @Autowired
     protected PromptRepository promptRepository;
+
+    @Autowired
+    protected PromptSearchRepository promptSearchRepository;
 
     @Autowired
     protected CategoryRepository categoryRepository;
@@ -60,8 +119,8 @@ public abstract class IntegrationTestSupport {
     @MockitoBean
     protected PromptAnalysisProvider promptAnalysisProvider;
 
-    @MockitoBean
-    protected PromptSearchRepository promptSearchRepository;
+    @Autowired
+    protected OpenSearchClient openSearchClient;
 
     @Autowired
     protected AnalysisService analysisService;
@@ -70,20 +129,34 @@ public abstract class IntegrationTestSupport {
     protected EntityManager entityManager;
 
     @Autowired
+    protected PromptQueryService promptQueryService;
+
+    @Autowired
+    protected OpenSearchOperations openSearchOperations;
+
+    @Autowired
     JdbcTemplate jdbcTemplate;
 
     @AfterEach
     void setup() {
         // PostgreSQL의 BASE TABLE만 조회 (VIEW는 제외)
         var tableNames = jdbcTemplate.queryForList(
-            "SELECT table_name FROM information_schema.tables " +
-                "WHERE table_schema = 'public' AND table_type = 'BASE TABLE'",
-            String.class
+                "SELECT table_name FROM information_schema.tables " +
+                        "WHERE table_schema = 'public' AND table_type = 'BASE TABLE'",
+                String.class
         );
 
         if (!tableNames.isEmpty()) {
             // db 컨텍스트를 공유하는 테스트가 있어서 테스트 하기 전 로우들 청소
             jdbcTemplate.execute("TRUNCATE TABLE " + String.join(", ", tableNames) + " CASCADE");
         }
+    }
+
+    private static String resolveIndexName() {
+        Document annotation = PromptDocument.class.getAnnotation(Document.class);
+        if (annotation == null || !StringUtils.hasText(annotation.indexName())) {
+            throw new IllegalStateException("PromptDocument must declare an indexName");
+        }
+        return annotation.indexName();
     }
 }

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -13,3 +13,13 @@ spring:
 #  threads:
 #    virtual:
 #      enabled: true
+
+
+
+logging:
+  level:
+    tracer: TRACE                         # cURL 로그 (요청/응답 바디 포함)
+    org.opensearch.client: TRACE          # OpenSearch Java client
+    org.apache.http: DEBUG                # Apache HTTP 요청/응답 헤더/라인
+    org.opensearch.data: DEBUG            # spring-data-opensearch (Template/Repository 내부)
+    org.springframework.data.elasticsearch.core: DEBUG  # (fork에 따라 이 쪽이 찍히는 경우도 있음)

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -10,11 +10,6 @@ spring:
   ai:
     openai:
       api-key: sk-proj-test
-#  threads:
-#    virtual:
-#      enabled: true
-
-
 
 logging:
   level:
@@ -22,4 +17,3 @@ logging:
     org.opensearch.client: TRACE          # OpenSearch Java client
     org.apache.http: DEBUG                # Apache HTTP 요청/응답 헤더/라인
     org.opensearch.data: DEBUG            # spring-data-opensearch (Template/Repository 내부)
-    org.springframework.data.elasticsearch.core: DEBUG  # (fork에 따라 이 쪽이 찍히는 경우도 있음)

--- a/backlog/tasks/task-009 - Phase-1.6-OpenSearch-연동-및-Prompt-Document-색인-(TDD).md
+++ b/backlog/tasks/task-009 - Phase-1.6-OpenSearch-연동-및-Prompt-Document-색인-(TDD).md
@@ -1,10 +1,10 @@
 ---
 id: task-009
 title: 'Phase 1.6: OpenSearch 연동 및 Prompt Document 색인 (TDD)'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2025-09-24 09:42'
-updated_date: '2025-10-28 13:48'
+updated_date: '2025-10-29 14:37'
 labels:
   - phase-1
   - backend

--- a/backlog/tasks/task-010 - Phase-1.7-프롬프트-조회-API-구현-(TDD).md
+++ b/backlog/tasks/task-010 - Phase-1.7-프롬프트-조회-API-구현-(TDD).md
@@ -1,0 +1,36 @@
+---
+id: task-010
+title: 'Phase 1.7: 프롬프트 조회 API 구현 (TDD)'
+status: In Progress
+assignee: []
+created_date: '2025-09-24 09:42'
+updated_date: '2025-10-29 14:37'
+labels:
+  - phase-1
+  - backend
+  - opensearch
+  - api
+  - tdd
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+OpenSearch에 색인된 프롬프트 데이터를 키워드, 태그, 카테고리 등 다양한 조건으로 조회할 수 있는 REST API를 구현합니다.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 검색 조건을 담는 'presentation/api/dto/PromptSearchRequest.java' DTO를 정의합니다.
+- [ ] #2 검색 요청을 받아 OpenSearch 쿼리를 실행하는 'application/service/PromptQueryService.java'를 구현합니다.
+- [ ] #3 GET '/api/v1/prompts/search' 요청을 처리하는 'presentation/api/PromptQueryController.java'를 구현합니다.
+- [ ] #4 TDD 사이클에 따라, 서비스 유닛 테스트와 컨트롤러 통합 테스트를 작성하고 통과시킵니다.
+- [ ] #5 OpenSearch 통합 테스트에서 복잡한 검색 쿼리가 올바르게 동작하는지 검증합니다.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+다양한 검색 조건을 처리하는 검색 API 설계 방법을 학습합니다. Spring Data Elasticsearch의 쿼리 메서드 또는 CriteriaQuery를 이용한 복잡한 검색 쿼리 작성법을 익힙니다.
+<!-- SECTION:NOTES:END -->

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   postgres:
     image: postgres:16.1
@@ -39,6 +38,39 @@ services:
     depends_on:
       - mongodb
 
+  opensearch:
+    image: opensearchproject/opensearch:2.17.0
+    container_name: ai_tracker_opensearch
+    environment:
+      - discovery.type=single-node
+      - DISABLE_SECURITY_PLUGIN=true
+      - DISABLE_INSTALL_DEMO_CONFIG=true
+      - OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    ports:
+      - "9200:9200"
+      - "9600:9600"
+    volumes:
+      - opensearch_data:/usr/share/opensearch/data
+
+  opensearch-dashboards:
+    image: opensearchproject/opensearch-dashboards:2.17.0
+    container_name: ai_tracker_opensearch_dashboards
+    depends_on:
+      - opensearch
+    environment:
+      - OPENSEARCH_HOSTS=http://opensearch:9200
+      - DISABLE_SECURITY_DASHBOARDS_PLUGIN=true
+    ports:
+      - "5601:5601"
+
 volumes:
   postgres_data:
   mongodb_data:
+  opensearch_data:


### PR DESCRIPTION
📝 Related Task

 - Closes #task-010

  📄 Description
  검색 및 분석을 위해 OpenSearch에 저장될 `PromptDocument` 모델을 정의하고, Spring Data OpenSearch 기
  반으로 분석된 프롬프트를 색인했습니다.
  이는 수집된 프롬프트 데이터의 검색 가능성을 확보하는 첫 단계로, 사용자가 원하는 정보를 빠르게 찾을
  수 있는 기반을 마련합니다.

  ✨ Key Changes
  - PromptDocument 비정규화 모델 + `@Document(indexName = "prompts")` 생성
  - `PromptSearchRepository`로 OpenSearch 색인/조회 추상화
  - `AnalysisService`에서 분석 완료 후 PromptDocument를 생성해 색인하도록 로직 확장
  - 통합 테스트에서 awaitility 기반으로 색인 결과 검증

  🤖 To Reviewers
  - OpenSearch 연동 설정(모델, 레포지토리, application 설정)이 Phase 1 요구사항에 맞는지 확인해주세요.
  - 비동기 분석(@Async) 이후 Awaitility로 색인 완료를 검증하는 방식이 안정적인지 봐주세요.
  - PromptDocument 비정규화 구조가 향후 검색·필터 요구사항을 충족할 수 있는지 피드백을 부탁드립니다.

  ✅ Checklist
  - [x] 코드 자체 리뷰 완료
  - [x] 프로젝트 스타일 가이드를 준수했습니다
  - [x] 변경 사항에 대한 테스트를 작성했습니다
  - [x] 모든 신규 및 기존 테스트를 통과했습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prompt search API with keyword, tag, category, payload and date-range filters; endpoints to search and list prompts.
  * Event-driven async indexing: analysis completion emits events used to create searchable documents; new search/request/response DTOs and result summaries.

* **Infrastructure**
  * Migration to OpenSearch with local dashboard support and compose setup; actuator enabled.

* **Tests**
  * Added OpenSearch-backed integration tests, controller/unit tests, and test helpers.

* **Bug Fixes**
  * Improved OpenSearch error logging and indexing flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->